### PR TITLE
feat: upgrade to pocketic version 8.0.0

### DIFF
--- a/packages/pic/postinstall.mjs
+++ b/packages/pic/postinstall.mjs
@@ -9,7 +9,7 @@ const __dirname = dirname(__filename);
 
 const IS_LINUX = process.platform === 'linux';
 const PLATFORM = IS_LINUX ? 'x86_64-linux' : 'x86_64-darwin';
-const VERSION = '7.0.0';
+const VERSION = '8.0.0';
 const DOWNLOAD_PATH = `https://github.com/dfinity/pocketic/releases/download/${VERSION}/pocket-ic-${PLATFORM}.gz`;
 
 const TARGET_PATH = resolve(__dirname, 'pocket-ic');


### PR DESCRIPTION
This PR adds support for PocketIC Server v8.0.0, by adapting the server response type mappings to match the new types and removing support for deprecated endpoints.