### PR TITLE
ci: update pipelines

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -11,13 +11,10 @@ on:
 
 jobs:
   create_release_pr:
-    name: Create Release PR
+    name: create_release_pr
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    environment:
-      name: npm
-      url: https://www.npmjs.com/package/@dfinity/pic
     steps:
       - name: Create GitHub App Token
         uses: actions/create-github-app-token@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,13 @@ env:
 
 jobs:
   release:
-    name: Release
+    name: release
     runs-on: ubuntu-latest
     outputs:
       is_beta: ${{ steps.is_beta.outputs.is_beta }}
+    environment:
+      name: npm
+      url: https://www.npmjs.com/package/@dfinity/pic
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -28,6 +31,12 @@ jobs:
         run: |
           IS_BETA=$([[ '${{ github.ref_name }}' == *b* ]] && echo true || echo false)
           echo "is_beta=$IS_BETA" >> $GITHUB_OUTPUT
+
+      - name: Build NPM packages
+        run: pnpm build
+
+      - name: Generate release notes
+        uses: dfinity/ci-tools/actions/generate-release-notes@main
 
       - name: Publish to npm
         env:


### PR DESCRIPTION
This PR fixes the release pipeline by moving the `npm` environment from the `create_release_pr` pipeline to the `release` pipeline. The NPM token contained in the `npm` environment is needed in the `release` pipeline to publish to NPM.

The `release` pipeline was also missing steps to build the NPM package, and generate release notes for the GitHub release artifact.