### PR TITLE
ci: add mising setup actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,12 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
 
+      - name: Setup Python
+        uses: dfinity/ci-tools/actions/setup-python@main
+
+      - name: Setup Commitizen
+        uses: dfinity/ci-tools/actions/setup-commitizen@main
+
       - name: Setup PNPM
         uses: dfinity/ci-tools/actions/setup-pnpm@main
 


### PR DESCRIPTION
This PR adds some missing setup steps for the release pipeline, namely "setup Python" and "setup Commitizen", these are needed by the "Generate release notes" step.
