### PR TITLE
ci: fix docs release pipeline

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -1,0 +1,44 @@
+name: release_docs
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build_docs:
+    name: Build Docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Setup PNPM
+        uses: dfinity/ci-tools/actions/setup-pnpm@main
+
+      - name: Build Docs
+        run: pnpm -F docs build
+
+      - name: Fix permissions
+        run: |
+          chmod -c -R +rX "docs/build/" | while read line; do
+            echo "::warning title=Invalid file permissions automatically fixed::$line"
+          done
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/build/
+
+  deploy_docs:
+    name: Deploy Docs
+    runs-on: ubuntu-latest
+    needs: build_docs
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     name: release
     runs-on: ubuntu-latest
     outputs:
-      is_beta: ${{ steps.is_beta.outputs.is_beta }}
+      is_beta: ${{ steps.is_beta.outputs.is_beta_tag }}
     environment:
       name: npm
       url: https://www.npmjs.com/package/@dfinity/pic
@@ -34,9 +34,7 @@ jobs:
 
       - name: Determine if Beta Release
         id: is_beta
-        run: |
-          IS_BETA=$([[ '${{ github.ref_name }}' == *b* ]] && echo true || echo false)
-          echo "is_beta=$IS_BETA" >> $GITHUB_OUTPUT
+        uses: dfinity/ci-tools/actions/is-beta-tag@main
 
       - name: Build NPM packages
         run: pnpm build
@@ -51,7 +49,7 @@ jobs:
           npm pack ./packages/pic/
 
           release_cmd="npm publish --verbose --access public"
-          if [ "${{ steps.is_beta.outputs.is_beta }}" = true ]; then
+          if [ "${{ steps.is_beta.outputs.is_beta_tag }}" = 'true' ]; then
             release_cmd="$release_cmd --tag beta"
           fi
           release_cmd="$release_cmd ./packages/pic/"
@@ -64,19 +62,20 @@ jobs:
           bodyFile: 'RELEASE_NOTES.md'
           tag: '${{ github.ref_name }}'
           commit: 'main'
-          prerelease: ${{ steps.is_beta.outputs.is_beta == true }}
-          makeLatest: ${{ steps.is_beta.outputs.is_beta == false }}
+          prerelease: ${{ steps.is_beta.outputs.is_beta_tag == 'true' }}
+          makeLatest: ${{ steps.is_beta.outputs.is_beta_tag == 'false' }}
 
   build_docs:
     name: Build Docs
     runs-on: ubuntu-latest
     needs: release
-    if: ${{ needs.release.outputs.is_beta == false }}
+    if: ${{ needs.release.outputs.is_beta == 'false' }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
 
-      - uses: ./.github/actions/setup-pnpm
+      - name: Setup PNPM
+        uses: dfinity/ci-tools/actions/setup-pnpm@main
 
       - name: Build Docs
         run: pnpm -F docs build


### PR DESCRIPTION
This PR fixes the docs release pipeline but using the `is_beta_tag` variable as a stringified boolean instead of a boolean.

A manual release pipeline is also added temporarily to release the docs, once the docs release is made this pipeline will be removed and future releases of the docs will happen alongside the release of the NPM package in the existing pipeline.
