### PR TITLE
ci: maintain major version zero

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -45,6 +45,7 @@ jobs:
         uses: dfinity/ci-tools/actions/bump-version@main
         with:
           prerelease: ${{ inputs.beta_release == true && 'beta' || '' }}
+          major_version_zero: true
 
       - name: Print Version
         run: echo "Bumping to version ${{ steps.bump_version.outputs.version }}"

--- a/.prettierignore
+++ b/.prettierignore
@@ -38,3 +38,5 @@
 .DS_Store
 pnpm-lock.yaml
 .cz.yaml
+
+CHANGELOG.md


### PR DESCRIPTION
This PR leverages the `major_version_zero` option of the `bump_version` CI action to keep our major version at zero even when breaking changes are made. The `CHANGELOG.md` is also ignored by Prettier to avoid clashes between how Commitizen formats the file and how Prettier wants it to be formatted.
