### PR TITLE
chore: bump PocketIC server version to v9.0.1

### DIFF
--- a/packages/pic/postinstall.mjs
+++ b/packages/pic/postinstall.mjs
@@ -9,7 +9,7 @@ const __dirname = dirname(__filename);
 
 const IS_LINUX = process.platform === 'linux';
 const PLATFORM = IS_LINUX ? 'x86_64-linux' : 'x86_64-darwin';
-const VERSION = '9.0.0';
+const VERSION = '9.0.1';
 const DOWNLOAD_PATH = `https://github.com/dfinity/pocketic/releases/download/${VERSION}/pocket-ic-${PLATFORM}.gz`;
 
 const TARGET_PATH = resolve(__dirname, 'pocket-ic');


### PR DESCRIPTION
This PR bumps the PocketIC server version to v9.0.1 which is a fix release for a PocketIC server crash.