### PR TITLE
chore: replace await_ingress_message by tick and ingress_status

### DIFF
--- a/packages/pic/src/pocket-ic-client-types.ts
+++ b/packages/pic/src/pocket-ic-client-types.ts
@@ -971,6 +971,43 @@ export function decodeSubmitCanisterCallResponse(
 
 //#endregion SubmitCanisterCall
 
+//#region IngressStatus
+
+export interface IngressStatusRequest {
+  message_id: EncodedCanisterCallId;
+  caller?: Principal;
+}
+
+export interface EncodedIngressStatusRequest {
+  raw_message_id: EncodedCanisterCallId;
+  raw_caller: string | null;
+}
+
+export function encodeIngressStatusRequest(req: IngressStatusRequest): EncodedIngressStatusRequest {
+  return {
+    raw_message_id: req.message_id,
+    raw_caller: req.caller ? base64EncodePrincipal(req.caller) : null,
+  };
+}
+
+export type IngressStatusResponse = CanisterCallResponse | null;
+
+export type EncodedIngressStatusResponse = EncodedCanisterCallResponse | {};
+
+export function decodeIngressStatusResponse(res: EncodedIngressStatusResponse): IngressStatusResponse {
+  if (isNil(res)) {
+    return null;
+  }
+
+  if ('Ok' in res || 'Err' in res) {
+    return decodeCanisterCallResponse(res);
+  }
+
+  throw new Error('Unexpected ingress status response {res}');
+}
+
+//#endregion IngressStatus
+
 //#region AwaitCanisterCall
 
 export type AwaitCanisterCallRequest = SubmitCanisterCallResponse;
@@ -987,13 +1024,5 @@ export function encodeAwaitCanisterCallRequest(
 }
 
 export type AwaitCanisterCallResponse = CanisterCallResponse;
-
-export type EncodedAwaitCanisterCallResponse = EncodedCanisterCallResponse;
-
-export function decodeAwaitCanisterCallResponse(
-  res: EncodedAwaitCanisterCallResponse,
-): AwaitCanisterCallResponse {
-  return decodeCanisterCallResponse(res);
-}
 
 //#endregion AwaitCanisterCall

--- a/packages/pic/src/pocket-ic-client-types.ts
+++ b/packages/pic/src/pocket-ic-client-types.ts
@@ -980,23 +980,23 @@ export interface IngressStatusRequest {
 
 export interface EncodedIngressStatusRequest {
   raw_message_id: EncodedCanisterCallId;
-  raw_caller: string | null;
+  raw_caller?: string;
 }
 
 export function encodeIngressStatusRequest(req: IngressStatusRequest): EncodedIngressStatusRequest {
   return {
     raw_message_id: req.message_id,
-    raw_caller: req.caller ? base64EncodePrincipal(req.caller) : null,
+    raw_caller: req.caller ? base64EncodePrincipal(req.caller) : undefined,
   };
 }
 
-export type IngressStatusResponse = CanisterCallResponse | null;
+export type IngressStatusResponse = CanisterCallResponse | undefined;
 
 export type EncodedIngressStatusResponse = EncodedCanisterCallResponse | {};
 
 export function decodeIngressStatusResponse(res: EncodedIngressStatusResponse): IngressStatusResponse {
   if (isNil(res)) {
-    return null;
+    return undefined;
   }
 
   if ('Ok' in res || 'Err' in res) {

--- a/packages/pic/src/pocket-ic-client-types.ts
+++ b/packages/pic/src/pocket-ic-client-types.ts
@@ -983,7 +983,9 @@ export interface EncodedIngressStatusRequest {
   raw_caller?: string;
 }
 
-export function encodeIngressStatusRequest(req: IngressStatusRequest): EncodedIngressStatusRequest {
+export function encodeIngressStatusRequest(
+  req: IngressStatusRequest,
+): EncodedIngressStatusRequest {
   return {
     raw_message_id: req.message_id,
     raw_caller: req.caller ? base64EncodePrincipal(req.caller) : undefined,
@@ -994,7 +996,9 @@ export type IngressStatusResponse = CanisterCallResponse | undefined;
 
 export type EncodedIngressStatusResponse = EncodedCanisterCallResponse | {};
 
-export function decodeIngressStatusResponse(res: EncodedIngressStatusResponse): IngressStatusResponse {
+export function decodeIngressStatusResponse(
+  res: EncodedIngressStatusResponse,
+): IngressStatusResponse {
   if (isNil(res)) {
     return undefined;
   }

--- a/packages/pic/src/pocket-ic-client.ts
+++ b/packages/pic/src/pocket-ic-client.ts
@@ -322,7 +322,9 @@ export class PocketIcClient {
     return decodeSubmitCanisterCallResponse(res);
   }
 
-  public async ingressStatus(req: IngressStatusRequest): Promise<IngressStatusResponse> {
+  public async ingressStatus(
+    req: IngressStatusRequest,
+  ): Promise<IngressStatusResponse> {
     this.assertInstanceNotDeleted();
 
     const res = await this.post<
@@ -349,7 +351,9 @@ export class PocketIcClient {
         return result;
       }
     }
-    throw new Error('PocketIC did not complete the update call within 100 rounds')
+    throw new Error(
+      'PocketIC did not complete the update call within 100 rounds',
+    );
   }
 
   private async post<B, R extends {}>(endpoint: string, body?: B): Promise<R> {


### PR DESCRIPTION
This PR replaces calls to the `await_ingress_message` endpoint of the PocketIC server by calls to the endpoints `tick` and `ingress_status` in a loop: the motivation for this change is to deprecate the (potentially long-running) endpoint `await_ingress_message` of the PocketIC server.