### PR TITLE
fix: state copy to not include parent folder

### DIFF
--- a/docs/docs/guides/06-working-with-the-nns.md
+++ b/docs/docs/guides/06-working-with-the-nns.md
@@ -99,7 +99,7 @@ export TARGET_PATH=/path/to/tests
 Copy the NNS state into your project:
 
 ```shell
-mkdir -p $TARGET_PATH && cp -r $NNS_STATE_PATH $TARGET_PATH/nns_state/
+mkdir -p $TARGET_PATH && cp -r $NNS_STATE_PATH/ $TARGET_PATH/nns_state/
 ```
 
 The state directory includes a lot of files, so if you don't want to commit all of them to your repository, you can compress the state directory and commit the archive instead.


### PR DESCRIPTION
<!-- Provide additional contextual information about the code changes below this line, then remove this line. -->

In the 0.13.x docs, it now uses a new `NNS_STATE_PATH` from the local replica shipped with dfx
`
export NNS_STATE_PATH=$(pwd)/.dfx/network/local/state/replicated_state/46bab453650b3f22d11f0ffe4d3057b855dd752f95eeccc69da5531e94598e2b
`

And then gives this command to copy the state over to the target folder
`
mkdir -p $TARGET_PATH && cp -r $NNS_STATE_PATH $TARGET_PATH/nns_state/
`

The only issue then what gets copied includes the root folder.

So I think this would solve the issue (note the / after $NNS_STATE_PATH).
`
mkdir -p $TARGET_PATH && cp -r $NNS_STATE_PATH/ $TARGET_PATH/nns_state/
`


