### PR TITLE
test: update dfx version for example projects

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "dfx": "0.24.0",
+  "dfx": "0.26.1",
   "output_env_file": ".env",
   "networks": {
     "local": {

--- a/packages/pic/src/http2-client.ts
+++ b/packages/pic/src/http2-client.ts
@@ -80,8 +80,8 @@ export class Http2Client {
           headers: { ...init.headers, ...JSON_HEADER },
         });
 
-        const resBody = (await res.json()) as ApiResponse<R>;
-        if (!resBody) {
+        const resBody = await getResBody<R>(res);
+        if (isNil(resBody)) {
           return resBody;
         }
 
@@ -134,7 +134,7 @@ export class Http2Client {
           body: reqBody,
         });
 
-        const resBody = (await res.json()) as ApiResponse<R>;
+        const resBody = await getResBody<R>(res);
         if (isNil(resBody)) {
           return resBody;
         }
@@ -195,6 +195,21 @@ export class Http2Client {
       },
       { intervalMs: POLLING_INTERVAL_MS, timeoutMs: this.processingTimeoutMs },
     );
+  }
+}
+
+async function getResBody<R extends {}>(
+  res: Response,
+): Promise<ApiResponse<R>> {
+  try {
+    return (await res.clone().json()) as ApiResponse<R>;
+  } catch (error) {
+    const message = await res.text();
+
+    console.error('Error parsing PocketIC server response body:', error);
+    console.error('Original body:', message);
+
+    throw new Error(message);
   }
 }
 


### PR DESCRIPTION
This PR updates the DFX version used in the example projects and also adds some better logging when the response from pocket ic server returns a plain text body instead of JSON, this happens when pic-js is not sending the correct request so this should not normally happen for end consumers, only contributors of the library.
