### PR TITLE
fix: set the create-prs environment

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -13,6 +13,7 @@ jobs:
   create_release_pr:
     name: create_release_pr
     runs-on: ubuntu-latest
+    environment: create-prs
     permissions:
       contents: write
     steps:

--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -10,5 +10,8 @@ jobs:
     uses: dfinity/ci-tools/.github/workflows/generate-changelog.yaml@main
     with:
       token_app_id: ${{ vars.PR_AUTOMATION_BOT_PUBLIC_APP_ID }}
+      environment: create-prs
+      owner: ${{ github.repository_owner }}
+      repository: ${{ github.event.repository.name }}
     secrets:
       token_private_key: ${{ secrets.PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY }}


### PR DESCRIPTION
The `PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY` secret will only be provided through the `create-prs` environment so we need to set this in the jobs that use this secret.