### PR TITLE
fix: increase poll timeout

### DIFF
--- a/packages/pic/src/pocket-ic-server.ts
+++ b/packages/pic/src/pocket-ic-server.ts
@@ -150,7 +150,7 @@ export class PocketIcServer {
 }
 
 const POLL_INTERVAL_MS = 100;
-const POLL_TIMEOUT_MS = 60_000;
+const POLL_TIMEOUT_MS = 90_000;
 
 class NullStream extends Writable {
   _write(


### PR DESCRIPTION
CI keeps failing, increasing the poll timeout when starting a PocketIC instance should fix it.
