### PR TITLE
fix: docs typos and exports

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -8,7 +8,7 @@
     "postbuild": "cp -r ./src/content/docs/* ./dist/${DOCS_VERSION:-local}/"
   },
   "devDependencies": {
-    "@dfinity/typedoc-plugin-icp-docs": "^0.0.2",
+    "@dfinity/typedoc-plugin-icp-docs": "^0.0.3",
     "typedoc": "^0.28.12",
     "typedoc-plugin-frontmatter": "^1.3.0",
     "typedoc-plugin-markdown": "^4.8.1"

--- a/packages/pic/src/pocket-ic-actor.ts
+++ b/packages/pic/src/pocket-ic-actor.ts
@@ -21,12 +21,12 @@ export interface ActorMethod<Args extends any[] = any[], Ret = any> {
 export type ActorInterface<T = object> = { [K in keyof T]: ActorMethod };
 
 /**
- * A typesafe class that implements the Candid interface of a canister.
+ * A type-safe class that implements the Candid interface of a canister.
  * This is acquired by calling {@link PocketIc.setupCanister | setupCanister}
  * or {@link PocketIc.createActor | createActor}.
  *
  * @category API
- * @typeparam T The type of the {@link Actor}. Must implement {@link ActorInterface}.
+ * @typeParam T The type of the {@link Actor}. Must implement {@link ActorInterface}.
  * @interface
  */
 export type Actor<T extends ActorInterface<T> = ActorInterface> = T & {

--- a/packages/pic/src/pocket-ic-types.ts
+++ b/packages/pic/src/pocket-ic-types.ts
@@ -3,6 +3,9 @@ import { ActorInterface, Actor } from './pocket-ic-actor';
 import { IDL } from '@dfinity/candid';
 import { CanisterInstallModeUpgradeOptions } from './management-canister';
 
+// Needed for the docs
+export { type CanisterInstallModeUpgradeOptions } from './management-canister';
+
 //#region CreateInstance
 
 /**

--- a/packages/pic/src/pocket-ic.ts
+++ b/packages/pic/src/pocket-ic.ts
@@ -567,7 +567,7 @@ export class PocketIc {
    *
    * @param interfaceFactory The InterfaceFactory to use for the {@link Actor}.
    * @param canisterId The Principal of the canister to create the {@link Actor} for.
-   * @typeparam T The type of the {@link Actor}. Must implement {@link ActorInterface}.
+   * @typeParam T The type of the {@link Actor}. Must implement {@link ActorInterface}.
    * @returns The {@link Actor} instance.
    *
    * @see [Principal](https://js.icp.build/core/latest/libs/principal/api/classes/principal/)
@@ -620,7 +620,7 @@ export class PocketIc {
    *
    * @param interfaceFactory The InterfaceFactory to use for the {@link DeferredActor}.
    * @param canisterId The Principal of the canister to create the {@link DeferredActor} for.
-   * @typeparam T The type of the {@link DeferredActor}. Must implement {@link ActorInterface}.
+   * @typeParam T The type of the {@link DeferredActor}. Must implement {@link ActorInterface}.
    * @returns The {@link DeferredActor} instance.
    *
    * @see [Principal](https://js.icp.build/core/latest/libs/principal/api/classes/principal/)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,8 +62,8 @@ importers:
   docs:
     devDependencies:
       '@dfinity/typedoc-plugin-icp-docs':
-        specifier: ^0.0.2
-        version: 0.0.2(typedoc-plugin-frontmatter@1.3.0(typedoc-plugin-markdown@4.8.1(typedoc@0.28.12(typescript@5.8.2))))(typedoc-plugin-markdown@4.8.1(typedoc@0.28.12(typescript@5.8.2)))(typedoc@0.28.12(typescript@5.8.2))
+        specifier: ^0.0.3
+        version: 0.0.3(typedoc-plugin-frontmatter@1.3.0(typedoc-plugin-markdown@4.8.1(typedoc@0.28.12(typescript@5.8.2))))(typedoc-plugin-markdown@4.8.1(typedoc@0.28.12(typescript@5.8.2)))(typedoc@0.28.12(typescript@5.8.2))
       typedoc:
         specifier: ^0.28.12
         version: 0.28.12(typescript@5.8.2)
@@ -334,8 +334,8 @@ packages:
   '@dfinity/principal@3.2.4':
     resolution: {integrity: sha512-7qTjDb9k/J/55k0/ZnD8s2+L+IgfG6K1lC7iywhQQL/4Qe0UIljUTasDk85kooY2QeNvWSl7MsLWp69LPBiYjw==}
 
-  '@dfinity/typedoc-plugin-icp-docs@0.0.2':
-    resolution: {integrity: sha512-p9BPiZWd5muhsNIv6E6j0bDTKZ2ETrDGdY0jipyZXlwvsM2zdhcxW0HyGpYleoEFZf3Gizs6CVt3jYzxfH9tqg==}
+  '@dfinity/typedoc-plugin-icp-docs@0.0.3':
+    resolution: {integrity: sha512-BewwIwWgJyqXcwTWBmpzQUh7H7MGPjVgZf1utPiqXv/7gJy2r7bK4AI07tEiKweewGm7vY9UxtE8PbUyMxkoUQ==}
     engines: {node: '>=22'}
     peerDependencies:
       typedoc: ^0.28.x
@@ -2613,7 +2613,7 @@ snapshots:
     dependencies:
       '@noble/hashes': 1.8.0
 
-  '@dfinity/typedoc-plugin-icp-docs@0.0.2(typedoc-plugin-frontmatter@1.3.0(typedoc-plugin-markdown@4.8.1(typedoc@0.28.12(typescript@5.8.2))))(typedoc-plugin-markdown@4.8.1(typedoc@0.28.12(typescript@5.8.2)))(typedoc@0.28.12(typescript@5.8.2))':
+  '@dfinity/typedoc-plugin-icp-docs@0.0.3(typedoc-plugin-frontmatter@1.3.0(typedoc-plugin-markdown@4.8.1(typedoc@0.28.12(typescript@5.8.2))))(typedoc-plugin-markdown@4.8.1(typedoc@0.28.12(typescript@5.8.2)))(typedoc@0.28.12(typescript@5.8.2))':
     dependencies:
       commander: 14.0.1
       typedoc: 0.28.12(typescript@5.8.2)


### PR DESCRIPTION
Fixes typos in docs and exports interface to remove most of the docs building warnings.
