### PR TITLE
feat: revert and add rounds as request parameter of awaitCall

### DIFF
--- a/packages/pic/src/pocket-ic-client-types.ts
+++ b/packages/pic/src/pocket-ic-client-types.ts
@@ -1154,7 +1154,7 @@ export type AwaitCanisterCallRequest = SubmitCanisterCallResponse & {
 export type EncodedAwaitCanisterCallRequest = EncodedCanisterCallId;
 
 export function encodeAwaitCanisterCallRequest(
-  req: AwaitCanisterCallRequest,
+  req: Omit<AwaitCanisterCallRequest, 'rounds'>,
 ): EncodedAwaitCanisterCallRequest {
   return {
     effective_principal: encodeEffectivePrincipal(req.effectivePrincipal),

--- a/packages/pic/src/pocket-ic-client-types.ts
+++ b/packages/pic/src/pocket-ic-client-types.ts
@@ -1147,7 +1147,9 @@ export function decodeIngressStatusResponse(
 
 //#region AwaitCanisterCall
 
-export type AwaitCanisterCallRequest = SubmitCanisterCallResponse;
+export type AwaitCanisterCallRequest = SubmitCanisterCallResponse & {
+  rounds?: number;
+};
 
 export type EncodedAwaitCanisterCallRequest = EncodedCanisterCallId;
 

--- a/packages/pic/src/pocket-ic-client.ts
+++ b/packages/pic/src/pocket-ic-client.ts
@@ -350,10 +350,10 @@ export class PocketIcClient {
     return decodeIngressStatusResponse(res);
   }
 
-  public async awaitCallWithRounds(
-    req: AwaitCanisterCallRequest,
-    rounds: number,
-  ): Promise<AwaitCanisterCallResponse> {
+  public async awaitCall({
+    rounds = AWAIT_INGRESS_STATUS_ROUNDS,
+    ...req
+  }: AwaitCanisterCallRequest): Promise<AwaitCanisterCallResponse> {
     this.assertInstanceNotDeleted();
     const encodedReq = {
       messageId: encodeAwaitCanisterCallRequest(req),
@@ -373,12 +373,6 @@ export class PocketIcClient {
     throw new Error(
       `PocketIC did not complete the update call within ${rounds} rounds`,
     );
-  }
-
-  public async awaitCall(
-    req: AwaitCanisterCallRequest,
-  ): Promise<AwaitCanisterCallResponse> {
-    return this.awaitCallWithRounds(req, AWAIT_INGRESS_STATUS_ROUNDS);
   }
 
   private async post<B, R extends {}>(


### PR DESCRIPTION
# Motivation

PR #220 introduced a new `rounds` option for `awaitCall` by duplicating the existing function with a new function called `awaitCallWithRounds`. I randomly noticed the PR and discussed it with @raymondk, as it felt like neither an idiomatic solution nor particularly ergonomic, since it could have been resolved by simply adding the new optional parameter as... an optional parameter. Which is what this PR does.

# Changes

- Revert function `awaitCallWithRounds` (not a breaking change, as this was not yet shipped)
- Add `rounds` to `AwaitCanisterCallRequest` parameter

# Notes

No tests, as none were provided in the original PR.

No documentation, as none was provided in the original PR and none exists in the codebase for the related module.