### PR TITLE
fix(pic): fail immediately on non-retryable PocketIC server errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - add http gateway support (#233)
 - bump PocketIC server to v12.0.0 (#231)
 
+### Fix
+
+- fail immediately on non-retryable PocketIC server errors instead of polling until timeout
+
 ## 0.18.0 (2026-01-21)
 
 ### BREAKING CHANGE

--- a/examples/nns_proxy/tests/src/nns-proxy.spec.ts
+++ b/examples/nns_proxy/tests/src/nns-proxy.spec.ts
@@ -33,6 +33,8 @@ describe('NNS Proxy', () => {
 
   beforeEach(async () => {
     // Enabling beta features to have a smoke test for that config.
+    // NNS operations (neuron creation, proposals) can take >30 s on CI,
+    // so use a longer processing timeout than the 30 s default.
     pic = await PocketIc.create(process.env.PIC_URL, {
       nns: {
         state: {
@@ -43,6 +45,7 @@ describe('NNS Proxy', () => {
       icpConfig: {
         betaFeatures: IcpConfigFlag.Enabled,
       },
+      processingTimeoutMs: 60_000,
     });
     await pic.setTime(new Date(2025, 4, 29).getTime());
     await pic.tick();

--- a/packages/pic/src/error.ts
+++ b/packages/pic/src/error.ts
@@ -39,14 +39,6 @@ export class BinNotFoundError extends Error {
   }
 }
 
-export class BinTimeoutError extends Error {
-  override readonly name = 'BinTimeoutError';
-
-  constructor() {
-    super('The PocketIC binary took too long to start. Please try again.');
-  }
-}
-
 export class ServerRequestTimeoutError extends Error {
   override readonly name = 'ServerRequestTimeoutError';
 
@@ -76,10 +68,14 @@ export class TopologyValidationError extends Error {
 }
 
 export class RetryableError extends Error {
-  override readonly name = 'RetryableError';
+  override readonly name: string = 'RetryableError';
+}
 
-  constructor(message: string) {
-    super(message);
+export class BinTimeoutError extends RetryableError {
+  override readonly name = 'BinTimeoutError';
+
+  constructor() {
+    super('The PocketIC binary took too long to start. Please try again.');
   }
 }
 

--- a/packages/pic/src/error.ts
+++ b/packages/pic/src/error.ts
@@ -1,4 +1,6 @@
 export class BinStartError extends Error {
+  override readonly name = 'BinStartError';
+
   constructor(cause: Error) {
     super(
       `There was an error starting the PocketIC Binary.
@@ -11,6 +13,8 @@ ${cause.stack}`,
 }
 
 export class BinStartMacOSArmError extends Error {
+  override readonly name = 'BinStartMacOSArmError';
+
   constructor(cause: Error) {
     super(
       `There was an error starting the PocketIC Binary.
@@ -26,6 +30,8 @@ ${cause.stack}`,
 }
 
 export class BinNotFoundError extends Error {
+  override readonly name = 'BinNotFoundError';
+
   constructor(picBinPath: string) {
     super(
       `Could not find the PocketIC binary. The PocketIC binary could not be found at ${picBinPath}. Please try installing @dfinity/pic again.`,
@@ -34,18 +40,24 @@ export class BinNotFoundError extends Error {
 }
 
 export class BinTimeoutError extends Error {
+  override readonly name = 'BinTimeoutError';
+
   constructor() {
     super('The PocketIC binary took too long to start. Please try again.');
   }
 }
 
 export class ServerRequestTimeoutError extends Error {
+  override readonly name = 'ServerRequestTimeoutError';
+
   constructor() {
     super('A request to the PocketIC server timed out.');
   }
 }
 
 export class InstanceDeletedError extends Error {
+  override readonly name = 'InstanceDeletedError';
+
   constructor() {
     super(
       'This PocketIC instance has been torn down. Please create a new instance before interacting further with PocketIC.',
@@ -54,9 +66,29 @@ export class InstanceDeletedError extends Error {
 }
 
 export class TopologyValidationError extends Error {
+  override readonly name = 'TopologyValidationError';
+
   constructor() {
     super(
       'The provided subnet configuration is invalid. At least one subnet must be configured and the number of both application and system subnets must be at least 0 (non-negative).',
     );
+  }
+}
+
+export class RetryableError extends Error {
+  override readonly name = 'RetryableError';
+
+  constructor(message: string) {
+    super(message);
+  }
+}
+
+export class ServerError extends Error {
+  override readonly name = 'ServerError';
+  public readonly serverMessage: string;
+
+  constructor(serverMessage: string) {
+    super(`PocketIC server error: ${serverMessage}`);
+    this.serverMessage = serverMessage;
   }
 }

--- a/packages/pic/src/error.ts
+++ b/packages/pic/src/error.ts
@@ -1,5 +1,5 @@
 export class BinStartError extends Error {
-  override readonly name = 'BinStartError';
+  override name = 'BinStartError';
 
   constructor(cause: Error) {
     super(
@@ -13,7 +13,7 @@ ${cause.stack}`,
 }
 
 export class BinStartMacOSArmError extends Error {
-  override readonly name = 'BinStartMacOSArmError';
+  override name = 'BinStartMacOSArmError';
 
   constructor(cause: Error) {
     super(
@@ -30,7 +30,7 @@ ${cause.stack}`,
 }
 
 export class BinNotFoundError extends Error {
-  override readonly name = 'BinNotFoundError';
+  override name = 'BinNotFoundError';
 
   constructor(picBinPath: string) {
     super(
@@ -40,7 +40,7 @@ export class BinNotFoundError extends Error {
 }
 
 export class ServerRequestTimeoutError extends Error {
-  override readonly name = 'ServerRequestTimeoutError';
+  override name = 'ServerRequestTimeoutError';
 
   constructor() {
     super('A request to the PocketIC server timed out.');
@@ -48,7 +48,7 @@ export class ServerRequestTimeoutError extends Error {
 }
 
 export class InstanceDeletedError extends Error {
-  override readonly name = 'InstanceDeletedError';
+  override name = 'InstanceDeletedError';
 
   constructor() {
     super(
@@ -58,7 +58,7 @@ export class InstanceDeletedError extends Error {
 }
 
 export class TopologyValidationError extends Error {
-  override readonly name = 'TopologyValidationError';
+  override name = 'TopologyValidationError';
 
   constructor() {
     super(
@@ -68,11 +68,11 @@ export class TopologyValidationError extends Error {
 }
 
 export class RetryableError extends Error {
-  override readonly name: string = 'RetryableError';
+  override name: string = 'RetryableError';
 }
 
 export class BinTimeoutError extends RetryableError {
-  override readonly name = 'BinTimeoutError';
+  override name = 'BinTimeoutError';
 
   constructor() {
     super('The PocketIC binary took too long to start. Please try again.');
@@ -80,7 +80,7 @@ export class BinTimeoutError extends RetryableError {
 }
 
 export class ServerError extends Error {
-  override readonly name = 'ServerError';
+  override name = 'ServerError';
   public readonly serverMessage: string;
 
   constructor(serverMessage: string) {

--- a/packages/pic/src/http2-client.ts
+++ b/packages/pic/src/http2-client.ts
@@ -170,14 +170,14 @@ export class Http2Client {
 
                 const stateBody = (await stateRes.json()) as ApiResponse<R>;
 
-                // the server is still processing, throw and try again
-                if (isNil(stateBody) || 'state_label' in stateBody) {
+                // the server is still processing or the op has not been
+                // registered yet — throw and try again
+                if (
+                  isNil(stateBody) ||
+                  'state_label' in stateBody ||
+                  'message' in stateBody
+                ) {
                   throw new RetryableError('Polling has not succeeded yet');
-                }
-
-                // the server encountered an error, fail immediately
-                if ('message' in stateBody) {
-                  throw new ServerError(stateBody.message);
                 }
 
                 // the request was successful, exit the loop

--- a/packages/pic/src/http2-client.ts
+++ b/packages/pic/src/http2-client.ts
@@ -216,7 +216,7 @@ async function getResBody<R extends {}>(
   } catch (error) {
     console.error('Error parsing PocketIC server response body:', error);
     // don't break the user's console by logging large response bodies
-    if (resBody.length < 10_240) {
+    if (resBody.length < MAX_LOGGABLE_BODY_LENGTH) {
       console.error('Original body:', resBody);
       throw new ServerError(resBody);
     }
@@ -226,6 +226,7 @@ async function getResBody<R extends {}>(
 }
 
 const POLLING_INTERVAL_MS = 10;
+export const MAX_LOGGABLE_BODY_LENGTH = 10_240;
 
 interface StartedOrBusyApiResponse {
   state_label: string;

--- a/packages/pic/src/http2-client.ts
+++ b/packages/pic/src/http2-client.ts
@@ -218,10 +218,10 @@ async function getResBody<R extends {}>(
     // don't break the user's console by logging large response bodies
     if (resBody.length < 10_240) {
       console.error('Original body:', resBody);
-      throw new Error(resBody);
+      throw new ServerError(resBody);
     }
 
-    throw new Error(String(error));
+    throw new ServerError(String(error));
   }
 }
 

--- a/packages/pic/src/http2-client.ts
+++ b/packages/pic/src/http2-client.ts
@@ -1,5 +1,9 @@
 import { JSONStringify } from 'json-with-bigint';
-import { ServerRequestTimeoutError } from './error';
+import {
+  RetryableError,
+  ServerError,
+  ServerRequestTimeoutError,
+} from './error';
 import { isNil, poll } from './util';
 
 export interface RequestOptions {
@@ -93,31 +97,26 @@ export class Http2Client {
           return resBody;
         }
 
-        // server encountered an error, throw and try again
+        // server encountered an error, fail immediately
         if ('message' in resBody) {
-          console.error(
-            'PocketIC server encountered an error',
-            resBody.message,
-          );
-
-          throw new Error(resBody.message);
+          throw new ServerError(resBody.message);
         }
 
         // the server has started processing or is busy
         if ('state_label' in resBody) {
           // the server is too busy to process the request, throw and try again
           if (res.status === 409) {
-            throw new Error('Server busy');
+            throw new RetryableError('Server busy');
           }
 
           // the server has started processing the request
           // this shouldn't happen for GET requests, throw and try again
           if (res.status === 202) {
-            throw new Error('Server started processing');
+            throw new RetryableError('Server started processing');
           }
 
           // something weird happened, throw and try again
-          throw new Error('Unknown state');
+          throw new RetryableError('Unknown state');
         }
 
         // the request was successful, exit the loop
@@ -148,21 +147,16 @@ export class Http2Client {
           return resBody;
         }
 
-        // server encountered an error, throw and try again
+        // server encountered an error, fail immediately
         if ('message' in resBody) {
-          console.error(
-            'PocketIC server encountered an error',
-            resBody.message,
-          );
-
-          throw new Error(resBody.message);
+          throw new ServerError(resBody.message);
         }
 
         // the server has started processing or is busy
         if ('state_label' in resBody) {
           // the server is too busy to process the request, throw and try again
           if (res.status === 409) {
-            throw new Error('Server busy');
+            throw new RetryableError('Server busy');
           }
 
           // the server has started processing the request, poll until it is done
@@ -176,13 +170,14 @@ export class Http2Client {
 
                 const stateBody = (await stateRes.json()) as ApiResponse<R>;
 
-                // the server encountered an error, throw and try again
-                if (
-                  isNil(stateBody) ||
-                  'message' in stateBody ||
-                  'state_label' in stateBody
-                ) {
-                  throw new Error('Polling has not succeeded yet');
+                // the server is still processing, throw and try again
+                if (isNil(stateBody) || 'state_label' in stateBody) {
+                  throw new RetryableError('Polling has not succeeded yet');
+                }
+
+                // the server encountered an error, fail immediately
+                if ('message' in stateBody) {
+                  throw new ServerError(stateBody.message);
                 }
 
                 // the request was successful, exit the loop
@@ -196,7 +191,7 @@ export class Http2Client {
           }
 
           // something weird happened, throw and try again
-          throw new Error('Unknown state');
+          throw new RetryableError('Unknown state');
         }
 
         // the request was successful, exit the loop

--- a/packages/pic/src/index.ts
+++ b/packages/pic/src/index.ts
@@ -9,3 +9,4 @@ export * from './pocket-ic-server-types';
 export * from './pocket-ic-server';
 export * from './pocket-ic-types';
 export * from './pocket-ic';
+export { ServerError } from './error';

--- a/packages/pic/src/pocket-ic-server.ts
+++ b/packages/pic/src/pocket-ic-server.ts
@@ -5,7 +5,7 @@ import {
   BinNotFoundError,
   BinStartError,
   BinStartMacOSArmError,
-  RetryableError,
+  BinTimeoutError,
 } from './error';
 import {
   exists,
@@ -95,12 +95,12 @@ export class PocketIcServer {
     return await poll(
       async () => {
         const portString = await readFileAsString(portFilePath).catch(() => {
-          throw new RetryableError('PocketIC binary not ready yet');
+          throw new BinTimeoutError();
         });
 
         const port = parseInt(portString);
         if (isNaN(port)) {
-          throw new RetryableError('PocketIC binary not ready yet');
+          throw new BinTimeoutError();
         }
 
         return new PocketIcServer(serverProcess, port);

--- a/packages/pic/src/pocket-ic-server.ts
+++ b/packages/pic/src/pocket-ic-server.ts
@@ -94,9 +94,17 @@ export class PocketIcServer {
 
     return await poll(
       async () => {
-        const portString = await readFileAsString(portFilePath).catch(() => {
-          throw new BinTimeoutError();
-        });
+        const portString = await readFileAsString(portFilePath).catch(
+          (err: unknown) => {
+            if (
+              err instanceof Error &&
+              (err as NodeJS.ErrnoException).code === 'ENOENT'
+            ) {
+              throw new BinTimeoutError();
+            }
+            throw err;
+          },
+        );
 
         const port = parseInt(portString);
         if (isNaN(port)) {

--- a/packages/pic/src/pocket-ic-server.ts
+++ b/packages/pic/src/pocket-ic-server.ts
@@ -5,7 +5,7 @@ import {
   BinNotFoundError,
   BinStartError,
   BinStartMacOSArmError,
-  BinTimeoutError,
+  RetryableError,
 } from './error';
 import {
   exists,
@@ -94,10 +94,13 @@ export class PocketIcServer {
 
     return await poll(
       async () => {
-        const portString = await readFileAsString(portFilePath);
+        const portString = await readFileAsString(portFilePath).catch(() => {
+          throw new RetryableError('PocketIC binary not ready yet');
+        });
+
         const port = parseInt(portString);
         if (isNaN(port)) {
-          throw new BinTimeoutError();
+          throw new RetryableError('PocketIC binary not ready yet');
         }
 
         return new PocketIcServer(serverProcess, port);
@@ -153,7 +156,7 @@ const POLL_INTERVAL_MS = 100;
 const POLL_TIMEOUT_MS = 90_000;
 
 class NullStream extends Writable {
-  _write(
+  override _write(
     _chunk: any,
     _encoding: BufferEncoding,
     callback: (error?: Error | null) => void,

--- a/packages/pic/src/util/poll.ts
+++ b/packages/pic/src/util/poll.ts
@@ -13,8 +13,6 @@ export async function poll<T extends (...args: any) => any>(
 
   return new Promise((resolve, reject) => {
     async function runPoll(): Promise<void> {
-      const currentTimeMs = Date.now();
-
       try {
         const result = await cb();
         return resolve(result);
@@ -23,7 +21,7 @@ export async function poll<T extends (...args: any) => any>(
           return reject(e);
         }
 
-        if (currentTimeMs - startTimeMs >= timeoutMs) {
+        if (Date.now() - startTimeMs >= timeoutMs) {
           return reject(e);
         }
 

--- a/packages/pic/src/util/poll.ts
+++ b/packages/pic/src/util/poll.ts
@@ -1,3 +1,5 @@
+import { RetryableError } from '../error';
+
 export interface PollOptions {
   intervalMs: number;
   timeoutMs: number;
@@ -17,6 +19,10 @@ export async function poll<T extends (...args: any) => any>(
         const result = await cb();
         return resolve(result);
       } catch (e) {
+        if (!(e instanceof RetryableError)) {
+          return reject(e);
+        }
+
         if (currentTimeMs - startTimeMs >= timeoutMs) {
           return reject(e);
         }

--- a/packages/pic/tests/src/time.spec.ts
+++ b/packages/pic/tests/src/time.spec.ts
@@ -144,4 +144,15 @@ describe('time', () => {
     // Time should not go backwards
     expect(finalTime).toEqual(initialTime);
   });
+
+  it('should fail immediately when setting time into the past', async () => {
+    const farPast = new Date('2000-01-01T00:00:00Z');
+
+    const startTime = Date.now();
+    await expect(fixture.pic.setTime(farPast)).rejects.toThrow(
+      /PocketIC server error/,
+    );
+    // Should fail almost immediately, not wait for the 30s timeout
+    expect(Date.now() - startTime).toBeLessThan(5000);
+  });
 });

--- a/packages/pic/tests/src/time.spec.ts
+++ b/packages/pic/tests/src/time.spec.ts
@@ -145,14 +145,15 @@ describe('time', () => {
     expect(finalTime).toEqual(initialTime);
   });
 
-  it('should fail immediately when setting time into the past', async () => {
+  // Used to retry until the ~30 s poll timeout.
+  // this only checks end-to-end timing against a real server.
+  it('should throw ServerError without retrying when the server rejects the request', async () => {
     const farPast = new Date('2000-01-01T00:00:00Z');
 
     const startTime = Date.now();
     await expect(fixture.pic.setTime(farPast)).rejects.toThrow(
       /PocketIC server error/,
     );
-    // Should fail almost immediately, not wait for the 30s timeout
     expect(Date.now() - startTime).toBeLessThan(5000);
   });
 });

--- a/packages/pic/tests/src/time.spec.ts
+++ b/packages/pic/tests/src/time.spec.ts
@@ -145,15 +145,15 @@ describe('time', () => {
     expect(finalTime).toEqual(initialTime);
   });
 
-  // Used to retry until the ~30 s poll timeout.
-  // this only checks end-to-end timing against a real server.
-  it('should throw ServerError without retrying when the server rejects the request', async () => {
+  // Previous versions used to retry until poll timeout.
+  it('should not get close to hitting timeout on non-retryable error', async () => {
     const farPast = new Date('2000-01-01T00:00:00Z');
+    const POLL_TIMEOUT_MS = 90_000; // PocketIC polling timeout in milliseconds
 
     const startTime = Date.now();
     await expect(fixture.pic.setTime(farPast)).rejects.toThrow(
       /PocketIC server error/,
     );
-    expect(Date.now() - startTime).toBeLessThan(5000);
+    expect(Date.now() - startTime).toBeLessThan(POLL_TIMEOUT_MS / 10);
   });
 });

--- a/packages/pic/tests/src/util/error.spec.ts
+++ b/packages/pic/tests/src/util/error.spec.ts
@@ -1,0 +1,55 @@
+import { RetryableError, ServerError } from '../../../src/error';
+
+describe('RetryableError', () => {
+  const error = new RetryableError('Server busy');
+
+  it('should be an instance of Error', () => {
+    expect(error).toBeInstanceOf(Error);
+  });
+
+  it('should be an instance of RetryableError', () => {
+    expect(error).toBeInstanceOf(RetryableError);
+  });
+
+  it('should have name set to RetryableError', () => {
+    expect(error.name).toBe('RetryableError');
+  });
+
+  it('should have the provided message', () => {
+    expect(error.message).toBe('Server busy');
+  });
+});
+
+describe('ServerError', () => {
+  const error = new ServerError(
+    'SettingTimeIntoPast((1620328630000000003, 946684800000000000))',
+  );
+
+  it('should be an instance of Error', () => {
+    expect(error).toBeInstanceOf(Error);
+  });
+
+  it('should be an instance of ServerError', () => {
+    expect(error).toBeInstanceOf(ServerError);
+  });
+
+  it('should not be an instance of RetryableError', () => {
+    expect(error).not.toBeInstanceOf(RetryableError);
+  });
+
+  it('should have name set to ServerError', () => {
+    expect(error.name).toBe('ServerError');
+  });
+
+  it('should have a prefixed message', () => {
+    expect(error.message).toBe(
+      'PocketIC server error: SettingTimeIntoPast((1620328630000000003, 946684800000000000))',
+    );
+  });
+
+  it('should expose the raw server message via serverMessage', () => {
+    expect(error.serverMessage).toBe(
+      'SettingTimeIntoPast((1620328630000000003, 946684800000000000))',
+    );
+  });
+});

--- a/packages/pic/tests/src/util/http2-client.spec.ts
+++ b/packages/pic/tests/src/util/http2-client.spec.ts
@@ -1,0 +1,143 @@
+import { Http2Client } from '../../../src/http2-client';
+import { ServerError } from '../../../src/error';
+
+const BASE_URL = 'http://localhost:9999';
+// high enough that retrying tests don't accidentally hit the poll timeout
+const TIMEOUT_MS = 5_000;
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function textResponse(body: string, status = 200): Response {
+  return new Response(body, { status });
+}
+
+describe('Http2Client', () => {
+  let client: Http2Client;
+  let fetchMock: jest.SpyInstance;
+
+  beforeEach(() => {
+    client = new Http2Client(BASE_URL, TIMEOUT_MS);
+    fetchMock = jest.spyOn(global, 'fetch');
+  });
+
+  afterEach(() => {
+    fetchMock.mockRestore();
+  });
+
+  describe('jsonGet', () => {
+    it('should return the parsed response on success', async () => {
+      fetchMock.mockResolvedValue(jsonResponse({ value: 42 }));
+
+      const result = await client.jsonGet<{ value: number }>({ path: '/test' });
+
+      expect(result).toEqual({ value: 42 });
+    });
+
+    it('should throw ServerError immediately on error response', async () => {
+      fetchMock.mockResolvedValue(jsonResponse({ message: 'SettingTimeIntoPast' }));
+
+      const start = Date.now();
+      const err = await client.jsonGet({ path: '/test' }).catch(e => e);
+
+      expect(err).toBeInstanceOf(ServerError);
+      expect(err.serverMessage).toBe('SettingTimeIntoPast');
+      expect(Date.now() - start).toBeLessThan(500);
+    });
+
+    it('should retry on 409 busy response and eventually succeed', async () => {
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse({ state_label: 'busy', op_id: '1' }, 409))
+        .mockResolvedValueOnce(jsonResponse({ value: 42 }));
+
+      const result = await client.jsonGet<{ value: number }>({ path: '/test' });
+
+      expect(result).toEqual({ value: 42 });
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('should throw ServerError immediately on parse failure with small body', async () => {
+      jest.spyOn(console, 'error').mockImplementation(() => {});
+      fetchMock.mockResolvedValue(textResponse('not valid json'));
+
+      const start = Date.now();
+      const err = await client.jsonGet({ path: '/test' }).catch(e => e);
+
+      expect(err).toBeInstanceOf(ServerError);
+      expect(err.serverMessage).toBe('not valid json');
+      expect(Date.now() - start).toBeLessThan(500);
+    });
+
+    it('should throw ServerError immediately on parse failure with large body', async () => {
+      jest.spyOn(console, 'error').mockImplementation(() => {});
+      fetchMock.mockResolvedValue(textResponse('x'.repeat(10_241)));
+
+      const start = Date.now();
+      const err = await client.jsonGet({ path: '/test' }).catch(e => e);
+
+      // large body: serverMessage is the stringify'd parse error, not the body
+      expect(err).toBeInstanceOf(ServerError);
+      expect(err.serverMessage).toMatch(/SyntaxError/);
+      expect(Date.now() - start).toBeLessThan(500);
+    });
+  });
+
+  describe('jsonPost', () => {
+    it('should return the parsed response on success', async () => {
+      fetchMock.mockResolvedValue(jsonResponse({ value: 42 }));
+
+      const result = await client.jsonPost<{ input: string }, { value: number }>({
+        path: '/test',
+        body: { input: 'hello' },
+      });
+
+      expect(result).toEqual({ value: 42 });
+    });
+
+    it('should retry on 409 busy response and eventually succeed', async () => {
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse({ state_label: 'busy', op_id: '1' }, 409))
+        .mockResolvedValueOnce(jsonResponse({ value: 42 }));
+
+      const result = await client.jsonPost<unknown, { value: number }>({ path: '/test' });
+
+      expect(result).toEqual({ value: 42 });
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('should poll read_graph on 202 until the result is ready', async () => {
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse({ state_label: 'processing', op_id: '42' }, 202))
+        // first read_graph poll: still processing
+        .mockResolvedValueOnce(jsonResponse({ state_label: 'processing', op_id: '42' }))
+        // second read_graph poll: done
+        .mockResolvedValueOnce(jsonResponse({ value: 42 }));
+
+      const result = await client.jsonPost<unknown, { value: number }>({ path: '/test' });
+
+      expect(result).toEqual({ value: 42 });
+      expect(fetchMock).toHaveBeenNthCalledWith(
+        2,
+        expect.stringContaining('/read_graph/processing/42'),
+        expect.any(Object),
+      );
+    });
+
+    it('should throw ServerError immediately when read_graph returns an error', async () => {
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse({ state_label: 'processing', op_id: '42' }, 202))
+        .mockResolvedValueOnce(jsonResponse({ message: 'ProcessingFailed' }));
+
+      const start = Date.now();
+      const err = await client.jsonPost({ path: '/test' }).catch(e => e);
+
+      expect(err).toBeInstanceOf(ServerError);
+      expect(err.serverMessage).toBe('ProcessingFailed');
+      expect(Date.now() - start).toBeLessThan(500);
+    });
+  });
+});

--- a/packages/pic/tests/src/util/http2-client.spec.ts
+++ b/packages/pic/tests/src/util/http2-client.spec.ts
@@ -39,7 +39,9 @@ describe('Http2Client', () => {
     });
 
     it('should throw ServerError immediately on error response', async () => {
-      fetchMock.mockResolvedValue(jsonResponse({ message: 'SettingTimeIntoPast' }));
+      fetchMock.mockResolvedValue(
+        jsonResponse({ message: 'SettingTimeIntoPast' }),
+      );
 
       const start = Date.now();
       const err = await client.jsonGet({ path: '/test' }).catch(e => e);
@@ -51,7 +53,9 @@ describe('Http2Client', () => {
 
     it('should retry on 409 busy response and eventually succeed', async () => {
       fetchMock
-        .mockResolvedValueOnce(jsonResponse({ state_label: 'busy', op_id: '1' }, 409))
+        .mockResolvedValueOnce(
+          jsonResponse({ state_label: 'busy', op_id: '1' }, 409),
+        )
         .mockResolvedValueOnce(jsonResponse({ value: 42 }));
 
       const result = await client.jsonGet<{ value: number }>({ path: '/test' });
@@ -90,7 +94,10 @@ describe('Http2Client', () => {
     it('should return the parsed response on success', async () => {
       fetchMock.mockResolvedValue(jsonResponse({ value: 42 }));
 
-      const result = await client.jsonPost<{ input: string }, { value: number }>({
+      const result = await client.jsonPost<
+        { input: string },
+        { value: number }
+      >({
         path: '/test',
         body: { input: 'hello' },
       });
@@ -100,10 +107,14 @@ describe('Http2Client', () => {
 
     it('should retry on 409 busy response and eventually succeed', async () => {
       fetchMock
-        .mockResolvedValueOnce(jsonResponse({ state_label: 'busy', op_id: '1' }, 409))
+        .mockResolvedValueOnce(
+          jsonResponse({ state_label: 'busy', op_id: '1' }, 409),
+        )
         .mockResolvedValueOnce(jsonResponse({ value: 42 }));
 
-      const result = await client.jsonPost<unknown, { value: number }>({ path: '/test' });
+      const result = await client.jsonPost<unknown, { value: number }>({
+        path: '/test',
+      });
 
       expect(result).toEqual({ value: 42 });
       expect(fetchMock).toHaveBeenCalledTimes(2);
@@ -111,13 +122,19 @@ describe('Http2Client', () => {
 
     it('should poll read_graph on 202 until the result is ready', async () => {
       fetchMock
-        .mockResolvedValueOnce(jsonResponse({ state_label: 'processing', op_id: '42' }, 202))
+        .mockResolvedValueOnce(
+          jsonResponse({ state_label: 'processing', op_id: '42' }, 202),
+        )
         // first read_graph poll: still processing
-        .mockResolvedValueOnce(jsonResponse({ state_label: 'processing', op_id: '42' }))
+        .mockResolvedValueOnce(
+          jsonResponse({ state_label: 'processing', op_id: '42' }),
+        )
         // second read_graph poll: done
         .mockResolvedValueOnce(jsonResponse({ value: 42 }));
 
-      const result = await client.jsonPost<unknown, { value: number }>({ path: '/test' });
+      const result = await client.jsonPost<unknown, { value: number }>({
+        path: '/test',
+      });
 
       expect(result).toEqual({ value: 42 });
       expect(fetchMock).toHaveBeenNthCalledWith(
@@ -129,7 +146,9 @@ describe('Http2Client', () => {
 
     it('should throw ServerError immediately when read_graph returns an error', async () => {
       fetchMock
-        .mockResolvedValueOnce(jsonResponse({ state_label: 'processing', op_id: '42' }, 202))
+        .mockResolvedValueOnce(
+          jsonResponse({ state_label: 'processing', op_id: '42' }, 202),
+        )
         .mockResolvedValueOnce(jsonResponse({ message: 'ProcessingFailed' }));
 
       const start = Date.now();

--- a/packages/pic/tests/src/util/http2-client.spec.ts
+++ b/packages/pic/tests/src/util/http2-client.spec.ts
@@ -1,4 +1,7 @@
-import { Http2Client } from '../../../src/http2-client';
+import {
+  Http2Client,
+  MAX_LOGGABLE_BODY_LENGTH,
+} from '../../../src/http2-client';
 import { ServerError } from '../../../src/error';
 
 const BASE_URL = 'http://localhost:9999';
@@ -85,7 +88,9 @@ describe('Http2Client', () => {
         .spyOn(console, 'error')
         .mockImplementation(() => {});
       try {
-        fetchMock.mockResolvedValue(textResponse('x'.repeat(10_241)));
+        fetchMock.mockResolvedValue(
+          textResponse('x'.repeat(MAX_LOGGABLE_BODY_LENGTH + 1)),
+        );
 
         const err = await client.jsonGet({ path: '/test' }).catch(e => e);
 

--- a/packages/pic/tests/src/util/http2-client.spec.ts
+++ b/packages/pic/tests/src/util/http2-client.spec.ts
@@ -143,20 +143,5 @@ describe('Http2Client', () => {
         expect.any(Object),
       );
     });
-
-    it('should throw ServerError immediately when read_graph returns an error', async () => {
-      fetchMock
-        .mockResolvedValueOnce(
-          jsonResponse({ state_label: 'processing', op_id: '42' }, 202),
-        )
-        .mockResolvedValueOnce(jsonResponse({ message: 'ProcessingFailed' }));
-
-      const start = Date.now();
-      const err = await client.jsonPost({ path: '/test' }).catch(e => e);
-
-      expect(err).toBeInstanceOf(ServerError);
-      expect(err.serverMessage).toBe('ProcessingFailed');
-      expect(Date.now() - start).toBeLessThan(500);
-    });
   });
 });

--- a/packages/pic/tests/src/util/http2-client.spec.ts
+++ b/packages/pic/tests/src/util/http2-client.spec.ts
@@ -43,12 +43,11 @@ describe('Http2Client', () => {
         jsonResponse({ message: 'SettingTimeIntoPast' }),
       );
 
-      const start = Date.now();
       const err = await client.jsonGet({ path: '/test' }).catch(e => e);
 
       expect(err).toBeInstanceOf(ServerError);
       expect(err.serverMessage).toBe('SettingTimeIntoPast');
-      expect(Date.now() - start).toBeLessThan(500);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
     });
 
     it('should retry on 409 busy response and eventually succeed', async () => {
@@ -65,28 +64,38 @@ describe('Http2Client', () => {
     });
 
     it('should throw ServerError immediately on parse failure with small body', async () => {
-      jest.spyOn(console, 'error').mockImplementation(() => {});
-      fetchMock.mockResolvedValue(textResponse('not valid json'));
+      const consoleSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      try {
+        fetchMock.mockResolvedValue(textResponse('not valid json'));
 
-      const start = Date.now();
-      const err = await client.jsonGet({ path: '/test' }).catch(e => e);
+        const err = await client.jsonGet({ path: '/test' }).catch(e => e);
 
-      expect(err).toBeInstanceOf(ServerError);
-      expect(err.serverMessage).toBe('not valid json');
-      expect(Date.now() - start).toBeLessThan(500);
+        expect(err).toBeInstanceOf(ServerError);
+        expect(err.serverMessage).toBe('not valid json');
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+      } finally {
+        consoleSpy.mockRestore();
+      }
     });
 
     it('should throw ServerError immediately on parse failure with large body', async () => {
-      jest.spyOn(console, 'error').mockImplementation(() => {});
-      fetchMock.mockResolvedValue(textResponse('x'.repeat(10_241)));
+      const consoleSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      try {
+        fetchMock.mockResolvedValue(textResponse('x'.repeat(10_241)));
 
-      const start = Date.now();
-      const err = await client.jsonGet({ path: '/test' }).catch(e => e);
+        const err = await client.jsonGet({ path: '/test' }).catch(e => e);
 
-      // large body: serverMessage is the stringify'd parse error, not the body
-      expect(err).toBeInstanceOf(ServerError);
-      expect(err.serverMessage).toMatch(/SyntaxError/);
-      expect(Date.now() - start).toBeLessThan(500);
+        // large body: serverMessage is the stringify'd parse error, not the body
+        expect(err).toBeInstanceOf(ServerError);
+        expect(err.serverMessage).toMatch(/SyntaxError/);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+      } finally {
+        consoleSpy.mockRestore();
+      }
     });
   });
 

--- a/packages/pic/tests/src/util/poll.spec.ts
+++ b/packages/pic/tests/src/util/poll.spec.ts
@@ -42,41 +42,39 @@ describe('poll', () => {
   });
 
   it('should immediately reject on non-retryable Error', async () => {
-    const startTime = Date.now();
+    let calls = 0;
 
     await expect(
       poll(
         () => {
+          calls++;
           throw new Error('fatal error');
         },
         { intervalMs: 10, timeoutMs: 5000 },
       ),
     ).rejects.toThrow('fatal error');
 
-    expect(Date.now() - startTime).toBeLessThan(1000);
+    expect(calls).toBe(1);
   });
 
   it('should immediately reject with a ServerError instance and preserve serverMessage', async () => {
-    const startTime = Date.now();
+    let calls = 0;
 
-    try {
-      await poll(
-        () => {
-          throw new ServerError('SettingTimeIntoPast');
-        },
-        { intervalMs: 10, timeoutMs: 5000 },
-      );
-      fail('Expected poll to reject');
-    } catch (e) {
-      expect(e).toBeInstanceOf(ServerError);
-      expect(e).not.toBeInstanceOf(RetryableError);
-      expect((e as ServerError).name).toBe('ServerError');
-      expect((e as ServerError).serverMessage).toBe('SettingTimeIntoPast');
-      expect((e as ServerError).message).toBe(
-        'PocketIC server error: SettingTimeIntoPast',
-      );
-    }
+    const err = await poll(
+      () => {
+        calls++;
+        throw new ServerError('SettingTimeIntoPast');
+      },
+      { intervalMs: 10, timeoutMs: 5000 },
+    ).catch(e => e);
 
-    expect(Date.now() - startTime).toBeLessThan(1000);
+    expect(calls).toBe(1);
+    expect(err).toBeInstanceOf(ServerError);
+    expect(err).not.toBeInstanceOf(RetryableError);
+    expect((err as ServerError).name).toBe('ServerError');
+    expect((err as ServerError).serverMessage).toBe('SettingTimeIntoPast');
+    expect((err as ServerError).message).toBe(
+      'PocketIC server error: SettingTimeIntoPast',
+    );
   });
 });

--- a/packages/pic/tests/src/util/poll.spec.ts
+++ b/packages/pic/tests/src/util/poll.spec.ts
@@ -1,0 +1,82 @@
+import { RetryableError, ServerError } from '../../../src/error';
+import { poll } from '../../../src/util/poll';
+
+describe('poll', () => {
+  it('should resolve when the callback succeeds immediately', async () => {
+    const result = await poll(() => 'success', {
+      intervalMs: 10,
+      timeoutMs: 1000,
+    });
+
+    expect(result).toBe('success');
+  });
+
+  it('should retry on RetryableError and resolve when eventually successful', async () => {
+    let attempts = 0;
+
+    const result = await poll(
+      () => {
+        attempts++;
+        if (attempts < 3) {
+          throw new RetryableError('not ready');
+        }
+        return 'success';
+      },
+      { intervalMs: 10, timeoutMs: 1000 },
+    );
+
+    expect(result).toBe('success');
+    expect(attempts).toBe(3);
+  });
+
+  it('should reject with a RetryableError instance after timeout', async () => {
+    const rejection = poll(
+      () => {
+        throw new RetryableError('always busy');
+      },
+      { intervalMs: 10, timeoutMs: 50 },
+    );
+
+    await expect(rejection).rejects.toBeInstanceOf(RetryableError);
+    await expect(rejection).rejects.toThrow('always busy');
+  });
+
+  it('should immediately reject on non-retryable Error', async () => {
+    const startTime = Date.now();
+
+    await expect(
+      poll(
+        () => {
+          throw new Error('fatal error');
+        },
+        { intervalMs: 10, timeoutMs: 5000 },
+      ),
+    ).rejects.toThrow('fatal error');
+
+    expect(Date.now() - startTime).toBeLessThan(1000);
+  });
+
+  it('should immediately reject with a ServerError instance and preserve serverMessage', async () => {
+    const startTime = Date.now();
+
+    try {
+      await poll(
+        () => {
+          throw new ServerError('SettingTimeIntoPast');
+        },
+        { intervalMs: 10, timeoutMs: 5000 },
+      );
+      fail('Expected poll to reject');
+    } catch (e) {
+      expect(e).toBeInstanceOf(ServerError);
+      expect(e).not.toBeInstanceOf(RetryableError);
+      expect((e as ServerError).name).toBe('ServerError');
+      expect((e as ServerError).serverMessage).toBe('SettingTimeIntoPast');
+      expect((e as ServerError).message).toBe(
+        'PocketIC server error: SettingTimeIntoPast',
+      );
+    }
+
+    expect(Date.now() - startTime).toBeLessThan(1000);
+  });
+});

--- a/packages/pic/tests/src/util/poll.spec.ts
+++ b/packages/pic/tests/src/util/poll.spec.ts
@@ -63,7 +63,7 @@ describe('poll', () => {
     const err = await poll(
       () => {
         calls++;
-        throw new ServerError('SettingTimeIntoPast');
+        throw new ServerError('something went wrong');
       },
       { intervalMs: 10, timeoutMs: 5000 },
     ).catch(e => e);
@@ -72,9 +72,9 @@ describe('poll', () => {
     expect(err).toBeInstanceOf(ServerError);
     expect(err).not.toBeInstanceOf(RetryableError);
     expect((err as ServerError).name).toBe('ServerError');
-    expect((err as ServerError).serverMessage).toBe('SettingTimeIntoPast');
+    expect((err as ServerError).serverMessage).toBe('something went wrong');
     expect((err as ServerError).message).toBe(
-      'PocketIC server error: SettingTimeIntoPast',
+      'PocketIC server error: something went wrong',
     );
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
     "types": ["node"],
     "module": "NodeNext"
   },


### PR DESCRIPTION
# Motivation

PicJS retries all failed requests until they time out, making it hard to get feedback when a call is malformed or hits a definitive server error.

---

# Summary

This PR introduces a RetryableError / ServerError distinction. The polling loop now only retries RetryableError. Any other error, including ServerError, which the server returns when a request is definitively invalid, propagates immediately. 

ServerError is also exported as part of the public API so callers can catch it by type and inspect .serverMessage directly, rather than matching against the error message string.

[SDK-2080](https://dfinity.atlassian.net/browse/SDK-2080)

[SDK-2080]: https://dfinity.atlassian.net/browse/SDK-2080?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ