### PR TITLE
fix(pic): include request path in PocketIC server error messages (#70)

### DIFF
--- a/packages/pic/src/http2-client.ts
+++ b/packages/pic/src/http2-client.ts
@@ -99,7 +99,7 @@ export class Http2Client {
 
         // server encountered an error, fail immediately
         if ('message' in resBody) {
-          throw new ServerError(resBody.message);
+          throw new ServerError(`${resBody.message} (${init.path})`);
         }
 
         // the server has started processing or is busy
@@ -149,7 +149,7 @@ export class Http2Client {
 
         // server encountered an error, fail immediately
         if ('message' in resBody) {
-          throw new ServerError(resBody.message);
+          throw new ServerError(`${resBody.message} (${init.path})`);
         }
 
         // the server has started processing or is busy

--- a/packages/pic/tests/src/util/http2-client.spec.ts
+++ b/packages/pic/tests/src/util/http2-client.spec.ts
@@ -49,7 +49,7 @@ describe('Http2Client', () => {
       const err = await client.jsonGet({ path: '/test' }).catch(e => e);
 
       expect(err).toBeInstanceOf(ServerError);
-      expect(err.serverMessage).toBe('SettingTimeIntoPast');
+      expect(err.serverMessage).toBe('SettingTimeIntoPast (/test)');
       expect(fetchMock).toHaveBeenCalledTimes(1);
     });
 

--- a/packages/pic/tests/src/util/http2-client.spec.ts
+++ b/packages/pic/tests/src/util/http2-client.spec.ts
@@ -134,6 +134,20 @@ describe('Http2Client', () => {
       expect(fetchMock).toHaveBeenCalledTimes(2);
     });
 
+    it('should throw ServerError immediately on error response', async () => {
+      fetchMock.mockResolvedValue(
+        jsonResponse({ message: 'InstanceNotFound' }),
+      );
+
+      const err = await client
+        .jsonPost({ path: '/test' })
+        .catch(e => e);
+
+      expect(err).toBeInstanceOf(ServerError);
+      expect(err.serverMessage).toBe('InstanceNotFound (/test)');
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
     it('should poll read_graph on 202 until the result is ready', async () => {
       fetchMock
         .mockResolvedValueOnce(

--- a/packages/pic/tests/src/util/http2-client.spec.ts
+++ b/packages/pic/tests/src/util/http2-client.spec.ts
@@ -139,9 +139,7 @@ describe('Http2Client', () => {
         jsonResponse({ message: 'InstanceNotFound' }),
       );
 
-      const err = await client
-        .jsonPost({ path: '/test' })
-        .catch(e => e);
+      const err = await client.jsonPost({ path: '/test' }).catch(e => e);
 
       expect(err).toBeInstanceOf(ServerError);
       expect(err.serverMessage).toBe('InstanceNotFound (/test)');


### PR DESCRIPTION
## Motivation

When a PocketIC instance is deleted while async operations are still in-flight, the resulting "Instance was deleted"
error provides no context about which call was orphaned, making it hard to track
down the offending line.

Closes #70

## Summary

- Include the request path in `ServerError` messages thrown by `jsonGet` and `jsonPost` in the HTTP client, e.g. `PocketIC server error: Instance was deleted (/api/v2/instances/0/read/query)`