### PR TITLE
feat: update canister settings to match spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Feat
+
+- **pic**: extend canister settings with `logVisibility`, `wasmMemoryLimit`, `wasmMemoryThreshold`, and `environmentVariables` for `createCanister`, `updateCanisterSettings`, and `canisterStatus` to match the current management canister interface
+
 ### Fix
 
 - **pic**: include request path in PocketIC server error messages (#70) (#249)

--- a/packages/pic/src/management-canister.ts
+++ b/packages/pic/src/management-canister.ts
@@ -4,12 +4,37 @@ import { decodeCandid, isNil } from './util';
 
 export const MANAGEMENT_CANISTER_ID = Principal.fromText('aaaaa-aa');
 
+const EnvironmentVariable = IDL.Record({
+  name: IDL.Text,
+  value: IDL.Text,
+});
+
+export interface EnvironmentVariable {
+  name: string;
+  value: string;
+}
+
+const LogVisibility = IDL.Variant({
+  controllers: IDL.Null,
+  public: IDL.Null,
+  allowed_viewers: IDL.Vec(IDL.Principal),
+});
+
+export type LogVisibility =
+  | { controllers: null }
+  | { public: null }
+  | { allowed_viewers: Principal[] };
+
 export interface CanisterSettings {
   controllers: [] | [Principal[]];
   compute_allocation: [] | [bigint];
   memory_allocation: [] | [bigint];
   freezing_threshold: [] | [bigint];
   reserved_cycles_limit: [] | [bigint];
+  log_visibility: [] | [LogVisibility];
+  wasm_memory_limit: [] | [bigint];
+  wasm_memory_threshold: [] | [bigint];
+  environment_variables: [] | [EnvironmentVariable[]];
 }
 
 export const CanisterSettings = IDL.Record({
@@ -18,6 +43,10 @@ export const CanisterSettings = IDL.Record({
   memory_allocation: IDL.Opt(IDL.Nat),
   freezing_threshold: IDL.Opt(IDL.Nat),
   reserved_cycles_limit: IDL.Opt(IDL.Nat),
+  log_visibility: IDL.Opt(LogVisibility),
+  wasm_memory_limit: IDL.Opt(IDL.Nat),
+  wasm_memory_threshold: IDL.Opt(IDL.Nat),
+  environment_variables: IDL.Opt(IDL.Vec(EnvironmentVariable)),
 });
 
 export interface CreateCanisterRequest {
@@ -179,6 +208,10 @@ const DefiniteCanisterSettings = IDL.Record({
   memory_allocation: IDL.Nat,
   freezing_threshold: IDL.Nat,
   reserved_cycles_limit: IDL.Nat,
+  log_visibility: LogVisibility,
+  wasm_memory_limit: IDL.Nat,
+  wasm_memory_threshold: IDL.Nat,
+  environment_variables: IDL.Vec(EnvironmentVariable),
 });
 
 export interface DefiniteCanisterSettings {
@@ -187,6 +220,10 @@ export interface DefiniteCanisterSettings {
   memory_allocation: bigint;
   freezing_threshold: bigint;
   reserved_cycles_limit: bigint;
+  log_visibility: LogVisibility;
+  wasm_memory_limit: bigint;
+  wasm_memory_threshold: bigint;
+  environment_variables: EnvironmentVariable[];
 }
 
 const QueryStats = IDL.Record({

--- a/packages/pic/src/pocket-ic-types.ts
+++ b/packages/pic/src/pocket-ic-types.ts
@@ -457,6 +457,27 @@ export interface CanisterFixture<T extends ActorInterface<T> = ActorInterface> {
 }
 
 /**
+ * Environment variable for canister settings.
+ *
+ * @category Types
+ */
+export interface EnvironmentVariable {
+  name: string;
+  value: string;
+}
+
+/**
+ * Log visibility for canister settings.
+ *
+ * @category Types
+ * @see [Principal](https://js.icp.build/core/latest/libs/principal/api/classes/principal/)
+ */
+export type LogVisibility =
+  | { controllers: null }
+  | { public: null }
+  | { allowedViewers: Principal[] };
+
+/**
  * Canister settings.
  *
  * @category Types
@@ -488,6 +509,27 @@ export interface CanisterSettings {
    * The reserved cycles limit of the canister.
    */
   reservedCyclesLimit?: bigint;
+
+  /**
+   * The log visibility of the canister.
+   */
+  logVisibility?: LogVisibility;
+
+  /**
+   * The WASM memory limit of the canister in bytes.
+   */
+  wasmMemoryLimit?: bigint;
+
+  /**
+   * The WASM memory threshold of the canister in bytes.
+   * The canister_on_low_wasm_memory function will be called when the canister's remaining wasm memory is below this threshold.
+   */
+  wasmMemoryThreshold?: bigint;
+
+  /**
+   * Environment variables exposed to the canister.
+   */
+  environmentVariables?: EnvironmentVariable[];
 }
 
 /**
@@ -761,6 +803,10 @@ export interface CanisterStatusResult {
     memoryAllocation: bigint;
     freezingThreshold: bigint;
     reservedCyclesLimit: bigint;
+    logVisibility: LogVisibility;
+    wasmMemoryLimit: bigint;
+    wasmMemoryThreshold: bigint;
+    environmentVariables: EnvironmentVariable[];
   };
 
   /**

--- a/packages/pic/src/pocket-ic.ts
+++ b/packages/pic/src/pocket-ic.ts
@@ -2,6 +2,8 @@ import { Principal } from '@icp-sdk/core/principal';
 import { IDL } from '@icp-sdk/core/candid';
 import {
   isNil,
+  logVisibilityFromIDL,
+  optLogVisibilityToIDL,
   optional,
   readFileAsBytes,
   sha256,
@@ -51,6 +53,7 @@ import {
 } from './pocket-ic-deferred-actor';
 
 const NANOS_PER_MILLISECOND = BigInt(1_000_000);
+
 // The IC ingress message limit is 2 MB, but that covers the entire message
 // envelope (signature, delegations, Candid overhead, etc.).
 // We use 1.85 MB to match dfx's conservative threshold.
@@ -182,9 +185,13 @@ export class PocketIc {
     cycles,
     freezingThreshold,
     memoryAllocation,
+    reservedCyclesLimit,
+    logVisibility,
+    wasmMemoryLimit,
+    wasmMemoryThreshold,
+    environmentVariables,
     targetCanisterId,
     targetSubnetId,
-    reservedCyclesLimit,
   }: SetupCanisterOptions): Promise<CanisterFixture<T>> {
     const canisterId = await this.createCanister({
       computeAllocation,
@@ -193,6 +200,10 @@ export class PocketIc {
       freezingThreshold,
       memoryAllocation,
       reservedCyclesLimit,
+      logVisibility,
+      wasmMemoryLimit,
+      wasmMemoryThreshold,
+      environmentVariables,
       targetCanisterId,
       targetSubnetId,
       sender,
@@ -236,6 +247,10 @@ export class PocketIc {
     freezingThreshold,
     memoryAllocation,
     reservedCyclesLimit,
+    logVisibility,
+    wasmMemoryLimit,
+    wasmMemoryThreshold,
+    environmentVariables,
     targetCanisterId,
     targetSubnetId,
   }: CreateCanisterOptions = {}): Promise<Principal> {
@@ -247,6 +262,10 @@ export class PocketIc {
           memory_allocation: optional(memoryAllocation),
           freezing_threshold: optional(freezingThreshold),
           reserved_cycles_limit: optional(reservedCyclesLimit),
+          log_visibility: optLogVisibilityToIDL(logVisibility),
+          wasm_memory_limit: optional(wasmMemoryLimit),
+          wasm_memory_threshold: optional(wasmMemoryThreshold),
+          environment_variables: optional(environmentVariables),
         },
       ],
       amount: [cycles],
@@ -594,6 +613,10 @@ export class PocketIc {
     freezingThreshold,
     memoryAllocation,
     reservedCyclesLimit,
+    logVisibility,
+    wasmMemoryLimit,
+    wasmMemoryThreshold,
+    environmentVariables,
     sender = Principal.anonymous(),
   }: UpdateCanisterSettingsOptions): Promise<void> {
     const payload = encodeUpdateCanisterSettingsRequest({
@@ -604,6 +627,10 @@ export class PocketIc {
         memory_allocation: optional(memoryAllocation),
         freezing_threshold: optional(freezingThreshold),
         reserved_cycles_limit: optional(reservedCyclesLimit),
+        log_visibility: optLogVisibilityToIDL(logVisibility),
+        wasm_memory_limit: optional(wasmMemoryLimit),
+        wasm_memory_threshold: optional(wasmMemoryThreshold),
+        environment_variables: optional(environmentVariables),
       },
     });
 
@@ -664,6 +691,10 @@ export class PocketIc {
         memoryAllocation: response.settings.memory_allocation,
         freezingThreshold: response.settings.freezing_threshold,
         reservedCyclesLimit: response.settings.reserved_cycles_limit,
+        logVisibility: logVisibilityFromIDL(response.settings.log_visibility),
+        wasmMemoryLimit: response.settings.wasm_memory_limit,
+        wasmMemoryThreshold: response.settings.wasm_memory_threshold,
+        environmentVariables: response.settings.environment_variables,
       },
       moduleHash: response.module_hash[0] ?? null,
       memorySize: response.memory_size,

--- a/packages/pic/src/util/candid.ts
+++ b/packages/pic/src/util/candid.ts
@@ -1,8 +1,27 @@
 import { IDL } from '@icp-sdk/core/candid';
+import type { LogVisibility as LogVisibilityIDL } from '../management-canister';
+import type { LogVisibility as LogVisibilityPIC } from '../pocket-ic-types';
 import { isNil } from './is-nil';
 
 export function optional<T>(value: T | undefined | null): [] | [T] {
   return isNil(value) ? [] : [value];
+}
+
+export type { LogVisibilityIDL };
+
+export function optLogVisibilityToIDL(
+  lv: LogVisibilityPIC | undefined,
+): [] | [LogVisibilityIDL] {
+  if (lv === undefined) return [];
+  if ('controllers' in lv) return [{ controllers: null }];
+  if ('public' in lv) return [{ public: null }];
+  return [{ allowed_viewers: lv.allowedViewers }];
+}
+
+export function logVisibilityFromIDL(lv: LogVisibilityIDL): LogVisibilityPIC {
+  if ('allowed_viewers' in lv) return { allowedViewers: lv.allowed_viewers };
+  if ('public' in lv) return { public: null };
+  return { controllers: null };
 }
 
 export function decodeCandid<T>(types: IDL.Type[], data: Uint8Array): T | null {

--- a/packages/pic/tests/src/pocket-ic.spec.ts
+++ b/packages/pic/tests/src/pocket-ic.spec.ts
@@ -17,6 +17,7 @@ const WASM_PATH = path.resolve(
 
 const CONTROLLER = generateRandomIdentity();
 const CONTROLLER_PRINCIPAL = CONTROLLER.getPrincipal();
+const OTHER_PRINCIPAL = generateRandomIdentity().getPrincipal();
 
 /**
  * Pads a WASM module to the target size by appending a custom section.
@@ -195,5 +196,50 @@ describe.each(wasmVariants)('PocketIc — %s WASM', (_label, targetSize) => {
     });
     expect(status.status).toEqual({ running: null });
     expect(status.moduleHash).toEqual(expectedHash);
+  });
+
+  it('should update canister settings', async () => {
+    const canisterId = await pic.createCanister({
+      sender: CONTROLLER_PRINCIPAL,
+      controllers: [CONTROLLER_PRINCIPAL],
+    });
+
+    const envVars = [
+      { name: 'FOO', value: 'bar' },
+      { name: 'BAZ', value: 'qux' },
+    ];
+    const wasmThreshold = 4_000_000n;
+
+    let status = await pic.canisterStatus({
+      canisterId,
+      sender: CONTROLLER_PRINCIPAL,
+    });
+    expect(status.settings.controllers).toEqual([CONTROLLER_PRINCIPAL]);
+
+    await pic.updateCanisterSettings({
+      canisterId,
+      controllers: [CONTROLLER_PRINCIPAL, OTHER_PRINCIPAL],
+      logVisibility: { public: null },
+      wasmMemoryThreshold: wasmThreshold,
+      environmentVariables: envVars,
+      sender: CONTROLLER_PRINCIPAL,
+    });
+
+    status = await pic.canisterStatus({
+      canisterId,
+      sender: CONTROLLER_PRINCIPAL,
+    });
+    expect(status.settings.controllers).toEqual(
+      expect.arrayContaining([CONTROLLER_PRINCIPAL, OTHER_PRINCIPAL]),
+    );
+    expect(status.settings.controllers).toHaveLength(2);
+
+    expect(status.settings.logVisibility).toEqual({ public: null });
+    expect(status.settings.wasmMemoryThreshold).toEqual(wasmThreshold);
+
+    expect(status.settings.environmentVariables).toEqual(
+      expect.arrayContaining(envVars),
+    );
+    expect(status.settings.environmentVariables).toHaveLength(envVars.length);
   });
 });


### PR DESCRIPTION
It has been a while since canister settings got updated. Extend canister settings with `logVisibility`, `wasmMemoryLimit`, `wasmMemoryThreshold`, and `environmentVariables` for `createCanister`, `updateCanisterSettings`, and `canisterStatus` to match the current management canister interface