### PR TITLE
fix(pic): use await_ingress_message endpoint to fix update call performance

### DIFF
--- a/packages/pic/src/pocket-ic-client-types.ts
+++ b/packages/pic/src/pocket-ic-client-types.ts
@@ -1163,6 +1163,14 @@ export function encodeAwaitCanisterCallRequest(
 
 export type AwaitCanisterCallResponse = CanisterCallResponse;
 
+export type EncodedAwaitCanisterCallResponse = EncodedCanisterCallResponse;
+
+export function decodeAwaitCanisterCallResponse(
+  res: EncodedAwaitCanisterCallResponse,
+): AwaitCanisterCallResponse {
+  return decodeCanisterCallResponse(res);
+}
+
 //#endregion AwaitCanisterCall
 
 //#region LiveMode

--- a/packages/pic/src/pocket-ic-client.ts
+++ b/packages/pic/src/pocket-ic-client.ts
@@ -1,5 +1,5 @@
 import { JSONParse } from 'json-with-bigint';
-import { Http2Client } from './http2-client';
+import { Http2Client, ServerRequestTimeoutError } from './http2-client';
 import {
   EncodedAddCyclesRequest,
   EncodedAddCyclesResponse,
@@ -366,12 +366,24 @@ export class PocketIcClient {
   ): Promise<AwaitCanisterCallResponse> {
     this.assertInstanceNotDeleted();
 
-    const res = await this.post<
-      EncodedAwaitCanisterCallRequest,
-      EncodedAwaitCanisterCallResponse
-    >('/update/await_ingress_message', encodeAwaitCanisterCallRequest(req));
+    try {
+      const res = await this.post<
+        EncodedAwaitCanisterCallRequest,
+        EncodedAwaitCanisterCallResponse
+      >('/update/await_ingress_message', encodeAwaitCanisterCallRequest(req));
 
-    return decodeAwaitCanisterCallResponse(res);
+      return decodeAwaitCanisterCallResponse(res);
+    } catch (err) {
+      if (err instanceof ServerRequestTimeoutError) {
+        throw new Error(
+          `awaitCall timed out while waiting for canister response. ` +
+            `If your update call can take longer than ${PROCESSING_TIME_VALUE_MS}ms, ` +
+            `increase the ` +
+            '`processingTimeoutMs` option when creating the PocketIC client.',
+        );
+      }
+      throw err;
+    }
   }
 
   public async autoProgress(): Promise<void> {

--- a/packages/pic/src/pocket-ic-client.ts
+++ b/packages/pic/src/pocket-ic-client.ts
@@ -73,7 +73,10 @@ import {
   decodeIngressStatusResponse,
   encodeAwaitCanisterCallRequest,
   AwaitCanisterCallRequest,
+  EncodedAwaitCanisterCallRequest,
   AwaitCanisterCallResponse,
+  EncodedAwaitCanisterCallResponse,
+  decodeAwaitCanisterCallResponse,
   EncodedGetTopologyResponse,
   EncodedGetControllersRequest,
   EncodedGetControllersResponse,
@@ -85,11 +88,10 @@ import {
   EncodedHttpGatewayRequest,
   EncodedHttpGatewayResponse,
 } from './pocket-ic-client-types';
-import { base64DecodePrincipal, isNil, isNotNil } from './util';
+import { base64DecodePrincipal, isNil } from './util';
 import { Principal } from '@icp-sdk/core/principal';
 
 const PROCESSING_TIME_VALUE_MS = 30_000;
-const AWAIT_INGRESS_STATUS_ROUNDS = 100;
 
 export class PocketIcClient {
   private isInstanceDeleted = false;
@@ -99,7 +101,6 @@ export class PocketIcClient {
     private readonly serverClient: Http2Client,
     private readonly instancePath: string,
     private readonly instanceId: number,
-    private readonly ingressMaxRetries: number,
   ) {}
 
   public static async create(
@@ -126,14 +127,10 @@ export class PocketIcClient {
 
     const instanceId = res.Created.instance_id;
 
-    const ingressMaxRetries =
-      req?.ingressMaxRetries ?? AWAIT_INGRESS_STATUS_ROUNDS;
-
     return new PocketIcClient(
       serverClient,
       `/instances/${instanceId}`,
       instanceId,
-      ingressMaxRetries,
     );
   }
 
@@ -368,24 +365,13 @@ export class PocketIcClient {
     req: AwaitCanisterCallRequest,
   ): Promise<AwaitCanisterCallResponse> {
     this.assertInstanceNotDeleted();
-    const encodedReq = {
-      messageId: encodeAwaitCanisterCallRequest(req),
-      // since this is always called immediately after making a call, there is no need to check the caller
-      // the `ingressStatus` method is not exposed publicly, so it is safe to assume that the caller is the same as the one who made the call
-      caller: undefined,
-    };
 
-    for (let i = 0; i < this.ingressMaxRetries; i++) {
-      await this.tick();
-      const result = await this.ingressStatus(encodedReq);
-      if (isNotNil(result)) {
-        return result;
-      }
-    }
+    const res = await this.post<
+      EncodedAwaitCanisterCallRequest,
+      EncodedAwaitCanisterCallResponse
+    >('/update/await_ingress_message', encodeAwaitCanisterCallRequest(req));
 
-    throw new Error(
-      `PocketIC did not complete the update call within ${this.ingressMaxRetries} rounds`,
-    );
+    return decodeAwaitCanisterCallResponse(res);
   }
 
   public async autoProgress(): Promise<void> {

--- a/packages/pic/src/pocket-ic-client.ts
+++ b/packages/pic/src/pocket-ic-client.ts
@@ -1,5 +1,6 @@
 import { JSONParse } from 'json-with-bigint';
-import { Http2Client, ServerRequestTimeoutError } from './http2-client';
+import { Http2Client } from './http2-client';
+import { ServerRequestTimeoutError } from './error';
 import {
   EncodedAddCyclesRequest,
   EncodedAddCyclesResponse,

--- a/packages/pic/src/pocket-ic-types.ts
+++ b/packages/pic/src/pocket-ic-types.ts
@@ -71,6 +71,8 @@ export interface CreateInstanceOptions {
   /**
    * @deprecated This option is no longer used. The PocketIC server now handles
    * ingress message processing internally via the `await_ingress_message` endpoint.
+   * Use {@link CreateInstanceOptions.processingTimeoutMs} to control how long update
+   * calls can wait for ingress processing to complete.
    */
   ingressMaxRetries?: number;
   /**

--- a/packages/pic/src/pocket-ic-types.ts
+++ b/packages/pic/src/pocket-ic-types.ts
@@ -69,7 +69,8 @@ export interface CreateInstanceOptions {
   processingTimeoutMs?: number;
 
   /**
-   * How many IngressStatusRounds all IC update calls should wait, till we get a timeout.
+   * @deprecated This option is no longer used. The PocketIC server now handles
+   * ingress message processing internally via the `await_ingress_message` endpoint.
    */
   ingressMaxRetries?: number;
   /**


### PR DESCRIPTION
## Motivation

PicJS currently polls for update call completion via repeated `tick()` + `ingressStatus()` HTTP requests in a loop. PocketIC v10.0.0+ has a known performance regression with this pattern.

- User report: https://forum.dfinity.org/t/dfinity-pic-js-release-announcements/65217/4
- Example failure: https://github.com/junobuild/juno/actions/runs/23088589705/job/67071317699?pr=2666

[SDK-2631](https://dfinity.atlassian.net/browse/SDK-2631)

## Summary

Replaced the `tick()` + `ingressStatus()` polling loop with a single call to PocketIC's dedicated `await_ingress_message` endpoint ([PocketIC changelog](https://github.com/dfinity/pocketic/blob/main/CHANGELOG.md#added-2)). This offloads ingress message processing to the PocketIC server, eliminating the overhead of repeated HTTP round-trips.

- Removed `ingressMaxRetries` constructor parameter and `AWAIT_INGRESS_STATUS_ROUNDS` constant
- Deprecated the `ingressMaxRetries` option in `CreateInstanceOptions`
- Added `decodeAwaitCanisterCallResponse` and related types

[SDK-2631]: https://dfinity.atlassian.net/browse/SDK-2631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ