### PR TITLE
feat(pic): add costSchedule option and bump PocketIC to v13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Feat
+
+- **pic**: add `costSchedule` option to `ApplicationSubnetConfig` for `Free` cycles cost schedule on application subnets
+
+### Chore
+
+- **pic**: bump PocketIC server to v13.0.0 (major server version bump; downloaded automatically on install)
+
 ## 0.21.0 (2026-03-18)
 
 ### Feat

--- a/packages/pic/postinstall.mjs
+++ b/packages/pic/postinstall.mjs
@@ -9,7 +9,7 @@ const __dirname = dirname(__filename);
 
 const IS_LINUX = process.platform === 'linux';
 const PLATFORM = IS_LINUX ? 'x86_64-linux' : 'x86_64-darwin';
-const VERSION = '12.0.0';
+const VERSION = '13.0.0';
 const DOWNLOAD_PATH = `https://github.com/dfinity/pocketic/releases/download/${VERSION}/pocket-ic-${PLATFORM}.gz`;
 
 const TARGET_PATH = resolve(__dirname, 'pocket-ic');

--- a/packages/pic/src/pocket-ic-client-types.ts
+++ b/packages/pic/src/pocket-ic-client-types.ts
@@ -39,7 +39,6 @@ export interface SubnetConfig<
 > {
   enableDeterministicTimeSlicing?: boolean;
   enableBenchmarkingInstructionLimits?: boolean;
-  costSchedule?: CanisterCyclesCostSchedule;
   state: T;
 }
 
@@ -64,7 +63,9 @@ export type SystemSubnetConfig = SubnetConfig<SystemSubnetStateConfig>;
 export type SystemSubnetStateConfig = NewSubnetStateConfig;
 
 export type ApplicationSubnetConfig =
-  SubnetConfig<ApplicationSubnetStateConfig>;
+  SubnetConfig<ApplicationSubnetStateConfig> & {
+    costSchedule?: CanisterCyclesCostSchedule;
+  };
 export type ApplicationSubnetStateConfig = NewSubnetStateConfig;
 
 export type VerifiedApplicationSubnetConfig =
@@ -167,11 +168,20 @@ export interface EncodedSubnetConfig {
 function encodeManySubnetConfigs<T extends SubnetConfig>(
   configs: T[] = [],
 ): EncodedSubnetConfig[] {
-  return configs.map(encodeSubnetConfig).filter(isNotNil);
+  return configs.map(config => encodeSubnetConfig(config)).filter(isNotNil);
+}
+
+function encodeManyApplicationSubnetConfigs(
+  configs: ApplicationSubnetConfig[] = [],
+): EncodedSubnetConfig[] {
+  return configs
+    .map(config => encodeSubnetConfig(config, config.costSchedule))
+    .filter(isNotNil);
 }
 
 function encodeSubnetConfig<T extends SubnetConfig>(
   config?: T,
+  costSchedule?: CanisterCyclesCostSchedule,
 ): EncodedSubnetConfig | undefined {
   if (isNil(config)) {
     return undefined;
@@ -188,7 +198,7 @@ function encodeSubnetConfig<T extends SubnetConfig>(
         instruction_config: encodeInstructionConfig(
           config.enableBenchmarkingInstructionLimits,
         ),
-        cost_schedule: encodeCostSchedule(config.costSchedule),
+        cost_schedule: encodeCostSchedule(costSchedule),
         state_config: 'New',
       };
     }
@@ -199,7 +209,7 @@ function encodeSubnetConfig<T extends SubnetConfig>(
         instruction_config: encodeInstructionConfig(
           config.enableBenchmarkingInstructionLimits,
         ),
-        cost_schedule: encodeCostSchedule(config.costSchedule),
+        cost_schedule: encodeCostSchedule(costSchedule),
         state_config: {
           FromPath: config.state.path,
         },
@@ -306,7 +316,7 @@ export function encodeCreateInstanceRequest(
       fiduciary: encodeSubnetConfig(defaultOptions.fiduciary),
       bitcoin: encodeSubnetConfig(defaultOptions.bitcoin),
       system: encodeManySubnetConfigs(defaultOptions.system),
-      application: encodeManySubnetConfigs(
+      application: encodeManyApplicationSubnetConfigs(
         defaultOptions.application ?? [defaultApplicationSubnet],
       ),
       // Required by the PocketIC v13 server contract; not user-configurable.

--- a/packages/pic/src/pocket-ic-client-types.ts
+++ b/packages/pic/src/pocket-ic-client-types.ts
@@ -9,6 +9,9 @@ import {
   isNotNil,
 } from './util';
 import { TopologyValidationError } from './error';
+import { CanisterCyclesCostSchedule } from './pocket-ic-types';
+
+export { CanisterCyclesCostSchedule };
 
 const NANOS_PER_MILLISECOND = BigInt(1_000_000);
 
@@ -36,6 +39,7 @@ export interface SubnetConfig<
 > {
   enableDeterministicTimeSlicing?: boolean;
   enableBenchmarkingInstructionLimits?: boolean;
+  costSchedule?: CanisterCyclesCostSchedule;
   state: T;
 }
 
@@ -122,6 +126,7 @@ export interface EncodedCreateInstanceSubnetConfig {
   bitcoin?: EncodedSubnetConfig;
   system: EncodedSubnetConfig[];
   application: EncodedSubnetConfig[];
+  cloud_engine: EncodedSubnetConfig[];
   verified_application: EncodedSubnetConfig[];
 }
 
@@ -155,6 +160,7 @@ export interface EncodedIcpFeatures {
 export interface EncodedSubnetConfig {
   dts_flag: 'Enabled' | 'Disabled';
   instruction_config: 'Production' | 'Benchmarking';
+  cost_schedule: 'Normal' | 'Free';
   state_config: 'New' | { FromPath: string };
 }
 
@@ -182,6 +188,7 @@ function encodeSubnetConfig<T extends SubnetConfig>(
         instruction_config: encodeInstructionConfig(
           config.enableBenchmarkingInstructionLimits,
         ),
+        cost_schedule: encodeCostSchedule(config.costSchedule),
         state_config: 'New',
       };
     }
@@ -192,6 +199,7 @@ function encodeSubnetConfig<T extends SubnetConfig>(
         instruction_config: encodeInstructionConfig(
           config.enableBenchmarkingInstructionLimits,
         ),
+        cost_schedule: encodeCostSchedule(config.costSchedule),
         state_config: {
           FromPath: config.state.path,
         },
@@ -212,6 +220,12 @@ function encodeInstructionConfig(
   return enableBenchmarkingInstructionLimits === true
     ? 'Benchmarking'
     : 'Production';
+}
+
+function encodeCostSchedule(
+  costSchedule?: CanisterCyclesCostSchedule,
+): EncodedSubnetConfig['cost_schedule'] {
+  return costSchedule ?? 'Normal';
 }
 
 function encodeIcpConfigFlag(
@@ -295,6 +309,8 @@ export function encodeCreateInstanceRequest(
       application: encodeManySubnetConfigs(
         defaultOptions.application ?? [defaultApplicationSubnet],
       ),
+      // Required by the PocketIC v13 server contract; not user-configurable.
+      cloud_engine: [],
       verified_application: encodeManySubnetConfigs(
         defaultOptions.verifiedApplication,
       ),

--- a/packages/pic/src/pocket-ic-types.ts
+++ b/packages/pic/src/pocket-ic-types.ts
@@ -114,6 +114,22 @@ export interface SubnetConfig<
 }
 
 /**
+ * The canister cycles cost schedule for a subnet.
+ * See the `SubnetSpec.cost_schedule` field in the PocketIC server.
+ */
+export enum CanisterCyclesCostSchedule {
+  /**
+   * Canisters are charged cycles as on the ICP mainnet.
+   */
+  Normal = 'Normal',
+
+  /**
+   * Canisters are not charged cycles. Only supported on application subnets.
+   */
+  Free = 'Free',
+}
+
+/**
  * Options for creating an NNS subnet.
  */
 export type NnsSubnetConfig = SubnetConfig<NnsSubnetStateConfig>;
@@ -179,7 +195,16 @@ export type SystemSubnetStateConfig = NewSubnetStateConfig;
  * Options for creating an application subnet.
  */
 export type ApplicationSubnetConfig =
-  SubnetConfig<ApplicationSubnetStateConfig>;
+  SubnetConfig<ApplicationSubnetStateConfig> & {
+    /**
+     * The canister cycles cost schedule for the subnet.
+     * Defaults to {@link CanisterCyclesCostSchedule.Normal}.
+     *
+     * Only supported on application subnets. The PocketIC server will reject
+     * non-default values on other subnet kinds.
+     */
+    costSchedule?: CanisterCyclesCostSchedule;
+  };
 
 /**
  * Options for an application subnet's state.

--- a/packages/pic/tests/src/cost-schedule.spec.ts
+++ b/packages/pic/tests/src/cost-schedule.spec.ts
@@ -1,0 +1,123 @@
+import { readFileSync } from 'node:fs';
+import { gunzipSync } from 'node:zlib';
+import path from 'node:path';
+import {
+  CanisterCyclesCostSchedule,
+  PocketIc,
+  SubnetStateType,
+  generateRandomIdentity,
+} from '../../src';
+import {
+  _SERVICE as TestCanister,
+  idlFactory,
+} from '../test-canister/declarations/test_canister.did';
+
+const WASM_PATH = path.resolve(
+  __dirname,
+  '..',
+  'test-canister',
+  'test_canister.wasm.gz',
+);
+
+function loadWasm(): Uint8Array {
+  return new Uint8Array(gunzipSync(readFileSync(WASM_PATH)));
+}
+
+const CONTROLLER = generateRandomIdentity();
+const CONTROLLER_PRINCIPAL = CONTROLLER.getPrincipal();
+
+const INITIAL_CYCLES = 1_000_000_000_000_000_000n;
+
+describe('SubnetConfig.costSchedule', () => {
+  let wasm: Uint8Array;
+
+  beforeAll(() => {
+    wasm = loadWasm();
+  });
+
+  it('defaults to Normal when costSchedule is omitted', async () => {
+    const pic = await PocketIc.create(process.env.PIC_URL, {
+      application: [{ state: { type: SubnetStateType.New } }],
+    });
+    try {
+      const canisterId = await pic.createCanister({
+        sender: CONTROLLER_PRINCIPAL,
+        controllers: [CONTROLLER_PRINCIPAL],
+        cycles: INITIAL_CYCLES,
+      });
+      await pic.installCode({
+        canisterId,
+        wasm,
+        sender: CONTROLLER_PRINCIPAL,
+      });
+
+      const actor = pic.createActor<TestCanister>(idlFactory, canisterId);
+      await actor.get_time();
+
+      const balanceBefore = await pic.getCyclesBalance(canisterId);
+
+      await pic.advanceTime(30 * 24 * 60 * 60 * 1000);
+      await pic.tick(5);
+      await actor.get_time();
+
+      const balanceAfter = await pic.getCyclesBalance(canisterId);
+
+      expect(balanceAfter).toBeLessThan(balanceBefore);
+    } finally {
+      await pic.tearDown();
+    }
+  });
+
+  it('accepts costSchedule: Free on an application subnet and preserves the cycles balance', async () => {
+    const pic = await PocketIc.create(process.env.PIC_URL, {
+      application: [
+        {
+          state: { type: SubnetStateType.New },
+          costSchedule: CanisterCyclesCostSchedule.Free,
+        },
+      ],
+    });
+    try {
+      const canisterId = await pic.createCanister({
+        sender: CONTROLLER_PRINCIPAL,
+        controllers: [CONTROLLER_PRINCIPAL],
+        cycles: INITIAL_CYCLES,
+      });
+      await pic.installCode({
+        canisterId,
+        wasm,
+        sender: CONTROLLER_PRINCIPAL,
+      });
+
+      const actor = pic.createActor<TestCanister>(idlFactory, canisterId);
+      await actor.get_time();
+
+      const balanceBefore = await pic.getCyclesBalance(canisterId);
+
+      await pic.advanceTime(30 * 24 * 60 * 60 * 1000);
+      await pic.tick(5);
+      await actor.get_time();
+
+      const balanceAfter = await pic.getCyclesBalance(canisterId);
+
+      expect(balanceAfter).toBe(balanceBefore);
+      expect(balanceAfter).toBe(INITIAL_CYCLES);
+    } finally {
+      await pic.tearDown();
+    }
+  });
+
+  it('rejects costSchedule: Free on a system subnet', async () => {
+    await expect(
+      PocketIc.create(process.env.PIC_URL, {
+        system: [
+          {
+            state: { type: SubnetStateType.New },
+            costSchedule: CanisterCyclesCostSchedule.Free,
+          } as any,
+        ],
+        application: [{ state: { type: SubnetStateType.New } }],
+      }),
+    ).rejects.toThrow(/cost.?schedule|Free|application/i);
+  });
+});

--- a/packages/pic/tests/src/cost-schedule.spec.ts
+++ b/packages/pic/tests/src/cost-schedule.spec.ts
@@ -28,7 +28,7 @@ const CONTROLLER_PRINCIPAL = CONTROLLER.getPrincipal();
 
 const INITIAL_CYCLES = 1_000_000_000_000_000_000n;
 
-describe('SubnetConfig.costSchedule', () => {
+describe('ApplicationSubnetConfig.costSchedule', () => {
   let wasm: Uint8Array;
 
   beforeAll(() => {
@@ -105,19 +105,5 @@ describe('SubnetConfig.costSchedule', () => {
     } finally {
       await pic.tearDown();
     }
-  });
-
-  it('rejects costSchedule: Free on a system subnet', async () => {
-    await expect(
-      PocketIc.create(process.env.PIC_URL, {
-        system: [
-          {
-            state: { type: SubnetStateType.New },
-            costSchedule: CanisterCyclesCostSchedule.Free,
-          } as any,
-        ],
-        application: [{ state: { type: SubnetStateType.New } }],
-      }),
-    ).rejects.toThrow(/cost.?schedule|Free|application/i);
   });
 });

--- a/packages/pic/tests/src/cost-schedule.spec.ts
+++ b/packages/pic/tests/src/cost-schedule.spec.ts
@@ -56,6 +56,8 @@ describe('ApplicationSubnetConfig.costSchedule', () => {
 
       const balanceBefore = await pic.getCyclesBalance(canisterId);
 
+      // Advance 30 days so idle resource costs (memory, compute allocation)
+      // accrue under the Normal schedule and drain the balance.
       await pic.advanceTime(30 * 24 * 60 * 60 * 1000);
       await pic.tick(5);
       await actor.get_time();


### PR DESCRIPTION
Add `costSchedule` on `ApplicationSubnetConfig` so application subnets can opt into the `Free` canister cycles cost schedule. The option is typed only on application subnets; the server rejects non-default values on other kinds, which is covered by a new test.

Bump the bundled PocketIC server to v13.0.0 and send the new required `cloud_engine` field (empty, not user-configurable) in the create-instance request.
