### PR TITLE
feat(pic): add ttl option to PocketIcServer.start

### DIFF
--- a/packages/pic/src/error.ts
+++ b/packages/pic/src/error.ts
@@ -67,6 +67,16 @@ export class TopologyValidationError extends Error {
   }
 }
 
+export class InvalidTtlError extends Error {
+  override name = 'InvalidTtlError';
+
+  constructor(ttl: number) {
+    super(
+      `Invalid ttl value ${ttl}. The ttl must be a non-negative integer representing seconds.`,
+    );
+  }
+}
+
 export class RetryableError extends Error {
   override name: string = 'RetryableError';
 }

--- a/packages/pic/src/pocket-ic-server-types.ts
+++ b/packages/pic/src/pocket-ic-server-types.ts
@@ -22,6 +22,7 @@ export interface StartServerOptions {
   /**
    * Time to live of the server in seconds since the last completed operation,
    * after which the server shuts down gracefully.
+   * Must be a non-negative integer.
    * If not provided, the server's default time to live is used.
    */
   ttl?: number;

--- a/packages/pic/src/pocket-ic-server-types.ts
+++ b/packages/pic/src/pocket-ic-server-types.ts
@@ -18,4 +18,11 @@ export interface StartServerOptions {
    * otherwise the binary downloaded by this package's install script.
    */
   binPath?: string;
+
+  /**
+   * Time to live of the server in seconds since the last completed operation,
+   * after which the server shuts down gracefully.
+   * If not provided, the server's default time to live is used.
+   */
+  ttl?: number;
 }

--- a/packages/pic/src/pocket-ic-server.ts
+++ b/packages/pic/src/pocket-ic-server.ts
@@ -70,7 +70,12 @@ export class PocketIcServer {
     const picFilePrefix = `pocket_ic_${pid}`;
     const portFilePath = tmpFile(`${picFilePrefix}.port`);
 
-    const serverProcess = spawn(binPath, ['--port-file', portFilePath]);
+    const serverArgs = ['--port-file', portFilePath];
+    if (options.ttl !== undefined) {
+      serverArgs.push('--ttl', options.ttl.toString());
+    }
+
+    const serverProcess = spawn(binPath, serverArgs);
 
     if (options.showRuntimeLogs) {
       serverProcess.stdout.pipe(process.stdout);

--- a/packages/pic/src/pocket-ic-server.ts
+++ b/packages/pic/src/pocket-ic-server.ts
@@ -6,6 +6,7 @@ import {
   BinStartError,
   BinStartMacOSArmError,
   BinTimeoutError,
+  InvalidTtlError,
 } from './error';
 import {
   exists,
@@ -72,6 +73,10 @@ export class PocketIcServer {
 
     const serverArgs = ['--port-file', portFilePath];
     if (options.ttl !== undefined) {
+      if (!Number.isInteger(options.ttl) || options.ttl < 0) {
+        throw new InvalidTtlError(options.ttl);
+      }
+
       serverArgs.push('--ttl', options.ttl.toString());
     }
 


### PR DESCRIPTION
The pocket-ic server shuts down after its default 60 second idle TTL. Test runs that interleave slow work between replica interactions — compiling canisters mid-run, for example — can exceed that window, and the server dies before the next request. This adds a `ttl` option to `StartServerOptions` that passes `--ttl <seconds>` to the spawned process; when omitted, no flag is passed and the server default applies as before.

Follow-up to [#276](https://github.com/dfinity/pic-js/pull/276).
